### PR TITLE
Adjustment of Gemini Workflow to use GEMINI_PAT

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: 'Acknowledge request'
         env:
-          GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
+          GITHUB_TOKEN: '${{ secrets.GEMINI_PAT || steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           MESSAGE: |-
             🤖 Hi @${{ github.actor }}, I've received your request, and I'm working on it now! You can track my progress [in the logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
@@ -194,7 +194,7 @@ jobs:
 
       - name: 'Send failure comment'
         env:
-          GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
+          GITHUB_TOKEN: '${{ secrets.GEMINI_PAT || steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           MESSAGE: |-
             🤖 I'm sorry @${{ github.actor }}, but I was unable to process your request. Please [see the logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -44,7 +44,7 @@ jobs:
           TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
           DESCRIPTION: '${{ github.event.pull_request.body || github.event.issue.body }}'
           EVENT_NAME: '${{ github.event_name }}'
-          GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
+          GITHUB_TOKEN: '${{ secrets.GEMINI_PAT || steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           IS_PULL_REQUEST: '${{ !!github.event.pull_request }}'
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -45,7 +45,7 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'gemini_pr_review'
         env:
-          GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
+          GITHUB_TOKEN: '${{ secrets.GEMINI_PAT || steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           ISSUE_TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.pull_request.body || github.event.issue.body }}'
           PULL_REQUEST_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           # Use the provided token so that the "gemini-cli" is the actor in the
           # log for what changed the labels.
-          github-token: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
+          github-token: '${{ secrets.GEMINI_PAT || steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           script: |-
             // Parse the available labels
             const availableLabels = (process.env.AVAILABLE_LABELS || '').split(',')


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to improve authentication and clarify label handling. The main focus is on prioritizing the use of the `GEMINI_PAT` secret for authentication across all Gemini-related workflows and making the labeling logic in the triage workflow more accurate and descriptive.

**Authentication improvements:**

* All Gemini-related workflow steps now use the `GEMINI_PAT` secret as the primary authentication token, falling back to other tokens only if it is not set. This change increases security and consistency when running Gemini automation. [[1]](diffhunk://#diff-0fda21141089d698a5b86e311b106913e8e2af6472fe9d63b7b61c28c828a7beL117-R117) [[2]](diffhunk://#diff-0fda21141089d698a5b86e311b106913e8e2af6472fe9d63b7b61c28c828a7beL197-R197) [[3]](diffhunk://#diff-5ef25f09b4c40fd8ba3ecbeede783df233ff486b770af5720d0da1a62fd4c8d3L47-R47) [[4]](diffhunk://#diff-88014883956befc3efb37d22efada05cb4c24c1808c469478218d4594c4b8b17L48-R48) [[5]](diffhunk://#diff-1f2006ab53957785d3337dc1160e80b48ac5e1b50d802410bba2333586674919L132-R132)

**Labeling logic improvements:**

* In the `gemini-triage.yml` workflow, the script now uses `addLabels` instead of `setLabels` to append labels to issues or pull requests, and updates log messages to reflect this change, making the labeling process more accurate and the logs clearer.