### PR TITLE
ci: ajustments main head only

### DIFF
--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -29,6 +29,7 @@ jobs:
   triage:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 7
+    if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -134,6 +135,7 @@ jobs:
     needs:
       - 'triage'
     if: |-
+      (github.event.repository.fork == false || github.event_name == 'workflow_dispatch') &&
       needs.triage.outputs.available_labels != '' &&
       needs.triage.outputs.available_labels != '[]' &&
       needs.triage.outputs.triaged_issues != '' &&


### PR DESCRIPTION
Sugestion for Problem:
The gemini-scheduled-triage pipeline was also running on forks of the repository, causing recurring failures and unnecessary error emails.


avoid this  hahaha:
<img width="962" height="317" alt="image" src="https://github.com/user-attachments/assets/6ae896f6-b996-4746-a881-ec16ff56e106" />
