### PR TITLE
Refactor Category & Item Dialogs: Add Duplicate Name Validation and Improve Maintainability

### DIFF
--- a/frontend/src/app/list/components/categories-management/category-dialog/category-dialog.component.html
+++ b/frontend/src/app/list/components/categories-management/category-dialog/category-dialog.component.html
@@ -1,0 +1,18 @@
+<h2 mat-dialog-title>{{ data.category ? "Editar" : "Nova" }} Categoria</h2>
+<mat-dialog-content>
+  <mat-form-field appearance="outline" class="w-100">
+    <mat-label>Nome</mat-label>
+    <input matInput [(ngModel)]="category.name" required />
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Cancelar</button>
+  <button
+    mat-raised-button
+    color="primary"
+    (click)="onSave()"
+    [disabled]="!category.name"
+  >
+    Salvar
+  </button>
+</mat-dialog-actions>

--- a/frontend/src/app/list/components/categories-management/category-dialog/category-dialog.component.scss
+++ b/frontend/src/app/list/components/categories-management/category-dialog/category-dialog.component.scss
@@ -1,0 +1,4 @@
+.w-100 {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/frontend/src/app/list/components/categories-management/category-dialog/category-dialog.component.ts
+++ b/frontend/src/app/list/components/categories-management/category-dialog/category-dialog.component.ts
@@ -22,34 +22,8 @@ import { Category } from '../../../../shared/interfaces/category.interface';
     MatInputModule,
     MatButtonModule,
   ],
-  template: `
-    <h2 mat-dialog-title>{{ data.category ? 'Editar' : 'Nova' }} Categoria</h2>
-    <mat-dialog-content>
-      <mat-form-field appearance="outline" class="w-100">
-        <mat-label>Nome</mat-label>
-        <input matInput [(ngModel)]="category.name" required />
-      </mat-form-field>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button (click)="onCancel()">Cancelar</button>
-      <button
-        mat-raised-button
-        color="primary"
-        (click)="onSave()"
-        [disabled]="!category.name"
-      >
-        Salvar
-      </button>
-    </mat-dialog-actions>
-  `,
-  styles: [
-    `
-      .w-100 {
-        width: 100%;
-        margin-bottom: 1rem;
-      }
-    `,
-  ],
+  templateUrl: './category-dialog.component.html',
+  styleUrls: ['./category-dialog.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CategoryDialogComponent {

--- a/frontend/src/app/list/components/category-dialog/category-dialog.component.html
+++ b/frontend/src/app/list/components/category-dialog/category-dialog.component.html
@@ -1,7 +1,9 @@
-<h2 mat-dialog-title>{{ isEdit ? "Editar Categoria" : "Nova Categoria" }}</h2>
+<form [formGroup]="categoryForm" (ngSubmit)="onSubmit()">
+  <h2 mat-dialog-title>
+    {{ isEdit() ? "Editar Categoria" : "Nova Categoria" }}
+  </h2>
 
-<mat-dialog-content>
-  <form [formGroup]="categoryForm">
+  <mat-dialog-content>
     <mat-form-field appearance="outline" class="w-100">
       <mat-label>Nome da Categoria</mat-label>
       <input
@@ -9,27 +11,25 @@
         formControlName="name"
         placeholder="Digite o nome da categoria"
       />
-      <mat-error *ngIf="categoryForm.get('name')?.hasError('required')">
-        Nome é obrigatório
-      </mat-error>
-      <mat-error *ngIf="categoryForm.get('name')?.hasError('minlength')">
-        Nome deve ter pelo menos 3 caracteres
-      </mat-error>
-      <mat-error *ngIf="categoryForm.get('name')?.hasError('duplicateName')">
-        Já existe uma categoria com este nome
-      </mat-error>
+      @if (categoryForm.get('name')?.hasError('required')) {
+      <mat-error> Nome é obrigatório </mat-error>
+      } @if (categoryForm.get('name')?.hasError('minlength')) {
+      <mat-error> Nome deve ter pelo menos 3 caracteres </mat-error>
+      } @if (categoryForm.get('name')?.hasError('duplicateName')) {
+      <mat-error> Já existe uma categoria com este nome </mat-error>
+      }
     </mat-form-field>
-  </form>
-</mat-dialog-content>
+  </mat-dialog-content>
 
-<mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()">Cancelar</button>
-  <button
-    mat-raised-button
-    color="primary"
-    (click)="onSubmit()"
-    [disabled]="!categoryForm.valid"
-  >
-    {{ isEdit ? "Atualizar" : "Criar" }}
-  </button>
-</mat-dialog-actions>
+  <mat-dialog-actions align="end">
+    <button mat-button type="button" (click)="onCancel()">Cancelar</button>
+    <button
+      mat-raised-button
+      color="primary"
+      type="submit"
+      [disabled]="!categoryForm.valid"
+    >
+      {{ isEdit() ? "Atualizar" : "Criar" }}
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/frontend/src/app/list/components/category-dialog/category-dialog.component.html
+++ b/frontend/src/app/list/components/category-dialog/category-dialog.component.html
@@ -15,6 +15,9 @@
       <mat-error *ngIf="categoryForm.get('name')?.hasError('minlength')">
         Nome deve ter pelo menos 3 caracteres
       </mat-error>
+      <mat-error *ngIf="categoryForm.get('name')?.hasError('duplicateName')">
+        Já existe uma categoria com este nome
+      </mat-error>
     </mat-form-field>
   </form>
 </mat-dialog-content>

--- a/frontend/src/app/list/components/category-dialog/category-dialog.component.html
+++ b/frontend/src/app/list/components/category-dialog/category-dialog.component.html
@@ -11,12 +11,14 @@
         formControlName="name"
         placeholder="Digite o nome da categoria"
       />
-      @if (categoryForm.get('name')?.hasError('required')) {
-      <mat-error> Nome é obrigatório </mat-error>
-      } @if (categoryForm.get('name')?.hasError('minlength')) {
-      <mat-error> Nome deve ter pelo menos 3 caracteres </mat-error>
-      } @if (categoryForm.get('name')?.hasError('duplicateName')) {
-      <mat-error> Já existe uma categoria com este nome </mat-error>
+      @if (categoryForm.get("name")?.hasError("required")) {
+        <mat-error> Nome é obrigatório </mat-error>
+      }
+      @if (categoryForm.get("name")?.hasError("minlength")) {
+        <mat-error> Nome deve ter pelo menos 3 caracteres </mat-error>
+      }
+      @if (categoryForm.get("name")?.hasError("duplicateName")) {
+        <mat-error> Já existe uma categoria com este nome </mat-error>
       }
     </mat-form-field>
   </mat-dialog-content>

--- a/frontend/src/app/list/components/category-dialog/category-dialog.component.spec.ts
+++ b/frontend/src/app/list/components/category-dialog/category-dialog.component.spec.ts
@@ -1,0 +1,105 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CategoryDialogComponent } from './category-dialog.component';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { CategoryService } from '../../../shared/services/category.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { of } from 'rxjs';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('CategoryDialogComponent - Duplicate Validation', () => {
+  let component: CategoryDialogComponent;
+  let fixture: ComponentFixture<CategoryDialogComponent>;
+  let categoryServiceSpy: jasmine.SpyObj<CategoryService>;
+
+  const mockCategories = [
+    { id: 1, name: 'Fruits', createdAt: '', updatedAt: '', deleted: false },
+    { id: 2, name: 'Dairy', createdAt: '', updatedAt: '', deleted: false }
+  ];
+
+  beforeEach(async () => {
+    categoryServiceSpy = jasmine.createSpyObj('CategoryService', ['getAllCategories', 'addCategory', 'updateCategory']);
+    categoryServiceSpy.getAllCategories.and.returnValue(of(mockCategories));
+
+    await TestBed.configureTestingModule({
+      imports: [
+        CategoryDialogComponent,
+        ReactiveFormsModule,
+        NoopAnimationsModule
+      ],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: jasmine.createSpy('close') } },
+        { provide: MAT_DIALOG_DATA, useValue: { isEdit: false } },
+        { provide: CategoryService, useValue: categoryServiceSpy },
+        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CategoryDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges(); // Triggers ngOnInit and loadCategories
+  });
+
+  it('should be invalid if name is a duplicate (case-insensitive and whitespace)', () => {
+    const nameControl = component.categoryForm.get('name');
+    
+    nameControl?.setValue('Fruits');
+    expect(nameControl?.hasError('duplicateName')).toBeTrue();
+
+    nameControl?.setValue('  fruits  ');
+    expect(nameControl?.hasError('duplicateName')).toBeTrue();
+
+    nameControl?.setValue('Meat');
+    expect(nameControl?.hasError('duplicateName')).toBeFalse();
+  });
+
+  it('should disable the submit button when the form is invalid', () => {
+    const submitBtn = fixture.nativeElement.querySelector('button[color="primary"]');
+    const nameControl = component.categoryForm.get('name');
+
+    // Case: Empty name
+    nameControl?.setValue('');
+    fixture.detectChanges();
+    expect(submitBtn.disabled).toBeTrue();
+
+    // Case: Duplicate name
+    nameControl?.setValue('Fruits');
+    fixture.detectChanges();
+    expect(submitBtn.disabled).toBeTrue();
+
+    // Case: Valid name
+    nameControl?.setValue('Vegetables');
+    fixture.detectChanges();
+    expect(submitBtn.disabled).toBeFalse();
+  });
+
+  it('should be valid when editing and keeping the same name', async () => {
+    // Reconfigure for Edit Mode
+    TestBed.resetTestingModule();
+    const originalCategory = mockCategories[0]; // "Fruits"
+    
+    await TestBed.configureTestingModule({
+      imports: [CategoryDialogComponent, ReactiveFormsModule, NoopAnimationsModule],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: jasmine.createSpy('close') } },
+        { provide: MAT_DIALOG_DATA, useValue: { isEdit: true, category: originalCategory } },
+        { provide: CategoryService, useValue: categoryServiceSpy },
+        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } }
+      ]
+    }).compileComponents();
+
+    const editFixture = TestBed.createComponent(CategoryDialogComponent);
+    const editComponent = editFixture.componentInstance;
+    editFixture.detectChanges();
+
+    const nameControl = editComponent.categoryForm.get('name');
+    
+    // Should be valid with its own name
+    nameControl?.setValue('Fruits');
+    expect(nameControl?.hasError('duplicateName')).toBeFalse();
+
+    // Should be invalid with ANOTHER existing name
+    nameControl?.setValue('Dairy');
+    expect(nameControl?.hasError('duplicateName')).toBeTrue();
+  });
+});

--- a/frontend/src/app/list/components/category-dialog/category-dialog.component.spec.ts
+++ b/frontend/src/app/list/components/category-dialog/category-dialog.component.spec.ts
@@ -14,25 +14,32 @@ describe('CategoryDialogComponent - Duplicate Validation', () => {
 
   const mockCategories = [
     { id: 1, name: 'Fruits', createdAt: '', updatedAt: '', deleted: false },
-    { id: 2, name: 'Dairy', createdAt: '', updatedAt: '', deleted: false }
+    { id: 2, name: 'Dairy', createdAt: '', updatedAt: '', deleted: false },
   ];
 
   beforeEach(async () => {
-    categoryServiceSpy = jasmine.createSpyObj('CategoryService', ['getAllCategories', 'addCategory', 'updateCategory']);
+    categoryServiceSpy = jasmine.createSpyObj('CategoryService', [
+      'getAllCategories',
+      'addCategory',
+      'updateCategory',
+    ]);
     categoryServiceSpy.getAllCategories.and.returnValue(of(mockCategories));
 
     await TestBed.configureTestingModule({
       imports: [
         CategoryDialogComponent,
         ReactiveFormsModule,
-        NoopAnimationsModule
+        NoopAnimationsModule,
       ],
       providers: [
-        { provide: MatDialogRef, useValue: { close: jasmine.createSpy('close') } },
+        {
+          provide: MatDialogRef,
+          useValue: { close: jasmine.createSpy('close') },
+        },
         { provide: MAT_DIALOG_DATA, useValue: { isEdit: false } },
         { provide: CategoryService, useValue: categoryServiceSpy },
-        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } }
-      ]
+        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CategoryDialogComponent);
@@ -42,7 +49,7 @@ describe('CategoryDialogComponent - Duplicate Validation', () => {
 
   it('should be invalid if name is a duplicate (case-insensitive and whitespace)', () => {
     const nameControl = component.categoryForm.get('name');
-    
+
     nameControl?.setValue('Fruits');
     expect(nameControl?.hasError('duplicateName')).toBeTrue();
 
@@ -54,7 +61,9 @@ describe('CategoryDialogComponent - Duplicate Validation', () => {
   });
 
   it('should disable the submit button when the form is invalid', () => {
-    const submitBtn = fixture.nativeElement.querySelector('button[color="primary"]');
+    const submitBtn = fixture.nativeElement.querySelector(
+      'button[color="primary"]',
+    );
     const nameControl = component.categoryForm.get('name');
 
     // Case: Empty name
@@ -77,15 +86,25 @@ describe('CategoryDialogComponent - Duplicate Validation', () => {
     // Reconfigure for Edit Mode
     TestBed.resetTestingModule();
     const originalCategory = mockCategories[0]; // "Fruits"
-    
+
     await TestBed.configureTestingModule({
-      imports: [CategoryDialogComponent, ReactiveFormsModule, NoopAnimationsModule],
+      imports: [
+        CategoryDialogComponent,
+        ReactiveFormsModule,
+        NoopAnimationsModule,
+      ],
       providers: [
-        { provide: MatDialogRef, useValue: { close: jasmine.createSpy('close') } },
-        { provide: MAT_DIALOG_DATA, useValue: { isEdit: true, category: originalCategory } },
+        {
+          provide: MatDialogRef,
+          useValue: { close: jasmine.createSpy('close') },
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { isEdit: true, category: originalCategory },
+        },
         { provide: CategoryService, useValue: categoryServiceSpy },
-        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } }
-      ]
+        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } },
+      ],
     }).compileComponents();
 
     const editFixture = TestBed.createComponent(CategoryDialogComponent);
@@ -93,7 +112,7 @@ describe('CategoryDialogComponent - Duplicate Validation', () => {
     editFixture.detectChanges();
 
     const nameControl = editComponent.categoryForm.get('name');
-    
+
     // Should be valid with its own name
     nameControl?.setValue('Fruits');
     expect(nameControl?.hasError('duplicateName')).toBeFalse();

--- a/frontend/src/app/list/components/category-dialog/category-dialog.component.ts
+++ b/frontend/src/app/list/components/category-dialog/category-dialog.component.ts
@@ -1,19 +1,38 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import {
+  AbstractControl,
   FormBuilder,
   FormGroup,
   ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
   Validators,
 } from '@angular/forms';
 import { CategoryService } from '../../../shared/services/category.service';
 import { Category } from '../../../shared/interfaces/category.interface';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialogModule } from '@angular/material/dialog';
+
+export function duplicateNameValidator(existingNames: string[], originalName?: string): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    if (!control.value) return null;
+    const name = control.value.trim().toLowerCase();
+    if (originalName && name === originalName.trim().toLowerCase()) return null;
+    return existingNames.some(existingName => existingName.trim().toLowerCase() === name)
+      ? { duplicateName: true }
+      : null;
+  };
+}
 
 @Component({
   selector: 'app-category-dialog',
@@ -30,7 +49,7 @@ import { MatDialogModule } from '@angular/material/dialog';
   styleUrls: ['./category-dialog.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CategoryDialogComponent {
+export class CategoryDialogComponent implements OnInit {
   private dialogRef = inject(MatDialogRef<CategoryDialogComponent>);
   private fb = inject(FormBuilder);
   private categoryService = inject(CategoryService);
@@ -42,6 +61,7 @@ export class CategoryDialogComponent {
 
   categoryForm: FormGroup;
   isEdit: boolean;
+  existingCategories: Category[] = [];
 
   constructor() {
     this.isEdit = this.data.isEdit;
@@ -54,6 +74,30 @@ export class CategoryDialogComponent {
         name: this.data.category.name,
       });
     }
+  }
+
+  ngOnInit(): void {
+    this.loadCategories();
+  }
+
+  loadCategories(): void {
+    this.categoryService.getAllCategories().subscribe({
+      next: (categories) => {
+        this.existingCategories = categories;
+        this.updateNameValidator();
+      },
+      error: () => {
+        this.snackBar.open('Erro ao carregar categorias para validação', 'Fechar', { duration: 3000 });
+      }
+    });
+  }
+
+  updateNameValidator(): void {
+    const names = this.existingCategories.map(c => c.name);
+    const originalName = this.isEdit && this.data.category ? this.data.category.name : undefined;
+    
+    this.categoryForm.get('name')?.addValidators(duplicateNameValidator(names, originalName));
+    this.categoryForm.get('name')?.updateValueAndValidity();
   }
 
   onSubmit(): void {

--- a/frontend/src/app/list/components/category-dialog/category-dialog.component.ts
+++ b/frontend/src/app/list/components/category-dialog/category-dialog.component.ts
@@ -1,34 +1,42 @@
 import {
-  ChangeDetectionStrategy,
   Component,
-  OnInit,
   inject,
+  OnInit,
+  signal,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import {
+  MatDialogRef,
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+} from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import {
-  AbstractControl,
   FormBuilder,
-  FormGroup,
   ReactiveFormsModule,
+  Validators,
+  AbstractControl,
   ValidationErrors,
   ValidatorFn,
-  Validators,
 } from '@angular/forms';
 import { CategoryService } from '../../../shared/services/category.service';
 import { Category } from '../../../shared/interfaces/category.interface';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatDialogModule } from '@angular/material/dialog';
 
-export function duplicateNameValidator(existingNames: string[], originalName?: string): ValidatorFn {
+export function duplicateNameValidator(
+  existingNames: string[],
+  originalName?: string,
+): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     if (!control.value) return null;
     const name = control.value.trim().toLowerCase();
     if (originalName && name === originalName.trim().toLowerCase()) return null;
-    return existingNames.some(existingName => existingName.trim().toLowerCase() === name)
+    return existingNames.some(
+      (existingName) => existingName.trim().toLowerCase() === name,
+    )
       ? { duplicateName: true }
       : null;
   };
@@ -50,71 +58,73 @@ export function duplicateNameValidator(existingNames: string[], originalName?: s
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CategoryDialogComponent implements OnInit {
-  private dialogRef = inject(MatDialogRef<CategoryDialogComponent>);
-  private fb = inject(FormBuilder);
-  private categoryService = inject(CategoryService);
-  private snackBar = inject(MatSnackBar);
-  private data = inject(MAT_DIALOG_DATA) as {
+  private readonly dialogRef = inject(MatDialogRef<CategoryDialogComponent>);
+  private readonly fb = inject(FormBuilder);
+  private readonly categoryService = inject(CategoryService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly data = inject(MAT_DIALOG_DATA) as {
     category?: Category;
     isEdit: boolean;
   };
 
-  categoryForm: FormGroup;
-  isEdit: boolean;
-  existingCategories: Category[] = [];
+  readonly categoryForm = this.fb.group({
+    name: ['', [Validators.required, Validators.minLength(3)]],
+  });
 
-  constructor() {
-    this.isEdit = this.data.isEdit;
-    this.categoryForm = this.fb.group({
-      name: ['', [Validators.required, Validators.minLength(3)]],
-    });
+  readonly isEdit = signal(this.data.isEdit);
+  readonly existingCategories = signal<Category[]>([]);
 
-    if (this.isEdit && this.data.category) {
+  ngOnInit(): void {
+    if (this.isEdit() && this.data.category) {
       this.categoryForm.patchValue({
         name: this.data.category.name,
       });
     }
-  }
-
-  ngOnInit(): void {
     this.loadCategories();
   }
 
   loadCategories(): void {
     this.categoryService.getAllCategories().subscribe({
       next: (categories) => {
-        this.existingCategories = categories;
+        this.existingCategories.set(categories);
         this.updateNameValidator();
       },
       error: () => {
-        this.snackBar.open('Erro ao carregar categorias para validação', 'Fechar', { duration: 3000 });
-      }
+        this.snackBar.open(
+          'Erro ao carregar categorias para validação',
+          'Fechar',
+          { duration: 3000 },
+        );
+      },
     });
   }
 
   updateNameValidator(): void {
-    const names = this.existingCategories.map(c => c.name);
-    const originalName = this.isEdit && this.data.category ? this.data.category.name : undefined;
-    
-    this.categoryForm.get('name')?.addValidators(duplicateNameValidator(names, originalName));
+    const names = this.existingCategories().map((c) => c.name);
+    const originalName =
+      this.isEdit() && this.data.category ? this.data.category.name : undefined;
+
+    this.categoryForm
+      .get('name')
+      ?.addValidators(duplicateNameValidator(names, originalName));
     this.categoryForm.get('name')?.updateValueAndValidity();
   }
 
   onSubmit(): void {
     if (this.categoryForm.valid) {
       const categoryData: Category = {
-        ...this.categoryForm.value,
+        name: this.categoryForm.value.name ?? '',
         id:
-          this.isEdit && this.data.category ? this.data.category.id : undefined,
+          this.isEdit() && this.data.category ? this.data.category.id : undefined,
         createdAt:
-          this.isEdit && this.data.category
+          this.isEdit() && this.data.category
             ? this.data.category.createdAt
             : new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         deleted: false,
       };
 
-      if (this.isEdit && this.data.category) {
+      if (this.isEdit() && this.data.category) {
         this.categoryService.updateCategory(categoryData).subscribe({
           next: () => {
             this.snackBar.open('Categoria atualizada com sucesso', 'Fechar', {

--- a/frontend/src/app/list/components/category-dialog/category-dialog.component.ts
+++ b/frontend/src/app/list/components/category-dialog/category-dialog.component.ts
@@ -115,7 +115,9 @@ export class CategoryDialogComponent implements OnInit {
       const categoryData: Category = {
         name: this.categoryForm.value.name ?? '',
         id:
-          this.isEdit() && this.data.category ? this.data.category.id : undefined,
+          this.isEdit() && this.data.category
+            ? this.data.category.id
+            : undefined,
         createdAt:
           this.isEdit() && this.data.category
             ? this.data.category.createdAt

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.html
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.html
@@ -1,46 +1,57 @@
-<h2 mat-dialog-title>{{ data.item ? 'Editar' : 'Novo' }} Item</h2>
-<mat-dialog-content>
-  <form [formGroup]="itemForm">
+<form [formGroup]="itemForm" (ngSubmit)="onSave()">
+  <h2 mat-dialog-title>{{ data.item ? 'Editar' : 'Novo' }} Item</h2>
+  <mat-dialog-content>
     <mat-form-field appearance="outline" class="w-100">
       <mat-label>Nome</mat-label>
       <input matInput formControlName="name" placeholder="Digite o nome do item" required>
-      <mat-error *ngIf="itemForm.get('name')?.hasError('required')">
-        Nome é obrigatório
-      </mat-error>
-      <mat-error *ngIf="itemForm.get('name')?.hasError('duplicateName')">
-        Já existe um item com este nome
-      </mat-error>
+      @if (itemForm.get('name')?.hasError('required')) {
+        <mat-error>
+          Nome é obrigatório
+        </mat-error>
+      }
+      @if (itemForm.get('name')?.hasError('duplicateName')) {
+        <mat-error>
+          Já existe um item com este nome
+        </mat-error>
+      }
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="w-100">
       <mat-label>Categoria</mat-label>
       <mat-select formControlName="idCategory" required>
-        <mat-option *ngFor="let category of categories" [value]="category.id">
-          {{category.name}}
-        </mat-option>
+        @for (category of categories(); track category.id) {
+          <mat-option [value]="category.id">
+            {{category.name}}
+          </mat-option>
+        }
       </mat-select>
-      <mat-error *ngIf="itemForm.get('idCategory')?.hasError('required')">
-        Categoria é obrigatória
-      </mat-error>
+      @if (itemForm.get('idCategory')?.hasError('required')) {
+        <mat-error>
+          Categoria é obrigatória
+        </mat-error>
+      }
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="w-100">
       <mat-label>Unidade</mat-label>
       <mat-select formControlName="idUnit" required>
-        <mat-option *ngFor="let unit of units" [value]="unit.id">
-          {{unit.name}} ({{unit.symbol}})
-        </mat-option>
+        @for (unit of units(); track unit.id) {
+          <mat-option [value]="unit.id">
+            {{unit.name}} ({{unit.symbol}})
+          </mat-option>
+        }
       </mat-select>
-      <mat-error *ngIf="itemForm.get('idUnit')?.hasError('required')">
-        Unidade é obrigatória
-      </mat-error>
+      @if (itemForm.get('idUnit')?.hasError('required')) {
+        <mat-error>
+          Unidade é obrigatória
+        </mat-error>
+      }
     </mat-form-field>
-  </form>
-</mat-dialog-content>
-<mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()">Cancelar</button>
-  <button mat-raised-button color="primary" (click)="onSave()"
-          [disabled]="itemForm.invalid">
-    Salvar
-  </button>
-</mat-dialog-actions>
+  </mat-dialog-content>
+  <mat-dialog-actions align="end">
+    <button mat-button type="button" (click)="onCancel()">Cancelar</button>
+    <button mat-raised-button color="primary" type="submit" [disabled]="itemForm.invalid">
+      Salvar
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.html
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.html
@@ -1,0 +1,46 @@
+<h2 mat-dialog-title>{{ data.item ? 'Editar' : 'Novo' }} Item</h2>
+<mat-dialog-content>
+  <form [formGroup]="itemForm">
+    <mat-form-field appearance="outline" class="w-100">
+      <mat-label>Nome</mat-label>
+      <input matInput formControlName="name" placeholder="Digite o nome do item" required>
+      <mat-error *ngIf="itemForm.get('name')?.hasError('required')">
+        Nome é obrigatório
+      </mat-error>
+      <mat-error *ngIf="itemForm.get('name')?.hasError('duplicateName')">
+        Já existe um item com este nome
+      </mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="w-100">
+      <mat-label>Categoria</mat-label>
+      <mat-select formControlName="idCategory" required>
+        <mat-option *ngFor="let category of categories" [value]="category.id">
+          {{category.name}}
+        </mat-option>
+      </mat-select>
+      <mat-error *ngIf="itemForm.get('idCategory')?.hasError('required')">
+        Categoria é obrigatória
+      </mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="w-100">
+      <mat-label>Unidade</mat-label>
+      <mat-select formControlName="idUnit" required>
+        <mat-option *ngFor="let unit of units" [value]="unit.id">
+          {{unit.name}} ({{unit.symbol}})
+        </mat-option>
+      </mat-select>
+      <mat-error *ngIf="itemForm.get('idUnit')?.hasError('required')">
+        Unidade é obrigatória
+      </mat-error>
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Cancelar</button>
+  <button mat-raised-button color="primary" (click)="onSave()"
+          [disabled]="itemForm.invalid">
+    Salvar
+  </button>
+</mat-dialog-actions>

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.html
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.html
@@ -1,18 +1,19 @@
 <form [formGroup]="itemForm" (ngSubmit)="onSave()">
-  <h2 mat-dialog-title>{{ data.item ? 'Editar' : 'Novo' }} Item</h2>
+  <h2 mat-dialog-title>{{ data.item ? "Editar" : "Novo" }} Item</h2>
   <mat-dialog-content>
     <mat-form-field appearance="outline" class="w-100">
       <mat-label>Nome</mat-label>
-      <input matInput formControlName="name" placeholder="Digite o nome do item" required>
-      @if (itemForm.get('name')?.hasError('required')) {
-        <mat-error>
-          Nome é obrigatório
-        </mat-error>
+      <input
+        matInput
+        formControlName="name"
+        placeholder="Digite o nome do item"
+        required
+      />
+      @if (itemForm.get("name")?.hasError("required")) {
+        <mat-error> Nome é obrigatório </mat-error>
       }
-      @if (itemForm.get('name')?.hasError('duplicateName')) {
-        <mat-error>
-          Já existe um item com este nome
-        </mat-error>
+      @if (itemForm.get("name")?.hasError("duplicateName")) {
+        <mat-error> Já existe um item com este nome </mat-error>
       }
     </mat-form-field>
 
@@ -21,14 +22,12 @@
       <mat-select formControlName="idCategory" required>
         @for (category of categories(); track category.id) {
           <mat-option [value]="category.id">
-            {{category.name}}
+            {{ category.name }}
           </mat-option>
         }
       </mat-select>
-      @if (itemForm.get('idCategory')?.hasError('required')) {
-        <mat-error>
-          Categoria é obrigatória
-        </mat-error>
+      @if (itemForm.get("idCategory")?.hasError("required")) {
+        <mat-error> Categoria é obrigatória </mat-error>
       }
     </mat-form-field>
 
@@ -37,20 +36,23 @@
       <mat-select formControlName="idUnit" required>
         @for (unit of units(); track unit.id) {
           <mat-option [value]="unit.id">
-            {{unit.name}} ({{unit.symbol}})
+            {{ unit.name }} ({{ unit.symbol }})
           </mat-option>
         }
       </mat-select>
-      @if (itemForm.get('idUnit')?.hasError('required')) {
-        <mat-error>
-          Unidade é obrigatória
-        </mat-error>
+      @if (itemForm.get("idUnit")?.hasError("required")) {
+        <mat-error> Unidade é obrigatória </mat-error>
       }
     </mat-form-field>
   </mat-dialog-content>
   <mat-dialog-actions align="end">
     <button mat-button type="button" (click)="onCancel()">Cancelar</button>
-    <button mat-raised-button color="primary" type="submit" [disabled]="itemForm.invalid">
+    <button
+      mat-raised-button
+      color="primary"
+      type="submit"
+      [disabled]="itemForm.invalid"
+    >
       Salvar
     </button>
   </mat-dialog-actions>

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.scss
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.scss
@@ -1,0 +1,4 @@
+.w-100 {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.spec.ts
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.spec.ts
@@ -9,6 +9,8 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ItemResponseDTO } from '../../../../shared/interfaces/item.interface';
+import { CategoryResponseDTO } from '../../../../shared/interfaces/category.interface';
+import { UnitResponseDTO } from '../../../../shared/interfaces/unit.interface';
 
 describe('ItemDialogComponent - Duplicate Validation', () => {
   let component: ItemDialogComponent;
@@ -21,8 +23,8 @@ describe('ItemDialogComponent - Duplicate Validation', () => {
     {
       id: 1,
       name: 'Apple',
-      category: { id: 1, name: 'Fruits' } as any,
-      unit: { id: 1, name: 'kg', symbol: 'kg' } as any,
+      category: { id: 1, name: 'Fruits' } as CategoryResponseDTO,
+      unit: { id: 1, symbol: 'kg' } as UnitResponseDTO,
     },
   ];
 

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.spec.ts
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.spec.ts
@@ -62,13 +62,28 @@ describe('ItemDialogComponent - Duplicate Validation', () => {
     expect(nameControl?.hasError('duplicateName')).toBeFalse();
   });
 
-  it('should be valid when editing and keeping its own name', () => {
-    component.data = { 
-      item: { name: 'Apple', idCategory: 1, idUnit: 1 } 
-    };
-    component.updateNameValidator();
+  it('should be valid when editing and keeping its own name', async () => {
+    // Reconfigure for Edit Mode
+    TestBed.resetTestingModule();
+    const originalItem = { name: 'Apple', idCategory: 1, idUnit: 1 };
     
-    const nameControl = component.itemForm.get('name');
+    await TestBed.configureTestingModule({
+      imports: [ItemDialogComponent, ReactiveFormsModule, NoopAnimationsModule],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: jasmine.createSpy('close') } },
+        { provide: MAT_DIALOG_DATA, useValue: { item: originalItem } },
+        { provide: ItemService, useValue: itemServiceSpy },
+        { provide: CategoryService, useValue: categoryServiceSpy },
+        { provide: UnitService, useValue: unitServiceSpy },
+        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } }
+      ]
+    }).compileComponents();
+
+    const editFixture = TestBed.createComponent(ItemDialogComponent);
+    const editComponent = editFixture.componentInstance;
+    editFixture.detectChanges();
+
+    const nameControl = editComponent.itemForm.get('name');
     nameControl?.setValue('Apple');
     expect(nameControl?.hasError('duplicateName')).toBeFalse();
   });

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.spec.ts
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ItemDialogComponent } from './item-dialog.component';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ItemService } from '../../../../shared/services/item.service';
+import { CategoryService } from '../../../../shared/services/category.service';
+import { UnitService } from '../../../../shared/services/unit.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { of } from 'rxjs';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('ItemDialogComponent - Duplicate Validation', () => {
+  let component: ItemDialogComponent;
+  let fixture: ComponentFixture<ItemDialogComponent>;
+  let itemServiceSpy: jasmine.SpyObj<ItemService>;
+  let categoryServiceSpy: jasmine.SpyObj<CategoryService>;
+  let unitServiceSpy: jasmine.SpyObj<UnitService>;
+
+  const mockItems = [
+    { id: 1, name: 'Apple', category: { id: 1, name: 'Fruits' }, unit: { id: 1, name: 'kg', symbol: 'kg' } }
+  ] as any;
+
+  beforeEach(async () => {
+    itemServiceSpy = jasmine.createSpyObj('ItemService', ['getAllItems']);
+    categoryServiceSpy = jasmine.createSpyObj('CategoryService', ['getAllCategories']);
+    unitServiceSpy = jasmine.createSpyObj('UnitService', ['getAllUnits']);
+
+    itemServiceSpy.getAllItems.and.returnValue(of(mockItems));
+    categoryServiceSpy.getAllCategories.and.returnValue(of([]));
+    unitServiceSpy.getAllUnits.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ItemDialogComponent,
+        ReactiveFormsModule,
+        NoopAnimationsModule
+      ],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: jasmine.createSpy('close') } },
+        { provide: MAT_DIALOG_DATA, useValue: { isEdit: false } },
+        { provide: ItemService, useValue: itemServiceSpy },
+        { provide: CategoryService, useValue: categoryServiceSpy },
+        { provide: UnitService, useValue: unitServiceSpy },
+        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ItemDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be invalid if name is a duplicate (including whitespace)', () => {
+    const nameControl = component.itemForm.get('name');
+    nameControl?.setValue('Apple');
+    expect(nameControl?.hasError('duplicateName')).toBeTrue();
+
+    nameControl?.setValue('  apple  ');
+    expect(nameControl?.hasError('duplicateName')).toBeTrue();
+
+    nameControl?.setValue('Banana');
+    expect(nameControl?.hasError('duplicateName')).toBeFalse();
+  });
+
+  it('should be valid when editing and keeping its own name', () => {
+    component.data = { 
+      item: { name: 'Apple', idCategory: 1, idUnit: 1 } 
+    };
+    component.updateNameValidator();
+    
+    const nameControl = component.itemForm.get('name');
+    nameControl?.setValue('Apple');
+    expect(nameControl?.hasError('duplicateName')).toBeFalse();
+  });
+});

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.spec.ts
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.spec.ts
@@ -8,6 +8,7 @@ import { UnitService } from '../../../../shared/services/unit.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ItemResponseDTO } from '../../../../shared/interfaces/item.interface';
 
 describe('ItemDialogComponent - Duplicate Validation', () => {
   let component: ItemDialogComponent;
@@ -16,13 +17,20 @@ describe('ItemDialogComponent - Duplicate Validation', () => {
   let categoryServiceSpy: jasmine.SpyObj<CategoryService>;
   let unitServiceSpy: jasmine.SpyObj<UnitService>;
 
-  const mockItems = [
-    { id: 1, name: 'Apple', category: { id: 1, name: 'Fruits' }, unit: { id: 1, name: 'kg', symbol: 'kg' } }
-  ] as any;
+  const mockItems: ItemResponseDTO[] = [
+    {
+      id: 1,
+      name: 'Apple',
+      category: { id: 1, name: 'Fruits' } as any,
+      unit: { id: 1, name: 'kg', symbol: 'kg' } as any,
+    },
+  ];
 
   beforeEach(async () => {
     itemServiceSpy = jasmine.createSpyObj('ItemService', ['getAllItems']);
-    categoryServiceSpy = jasmine.createSpyObj('CategoryService', ['getAllCategories']);
+    categoryServiceSpy = jasmine.createSpyObj('CategoryService', [
+      'getAllCategories',
+    ]);
     unitServiceSpy = jasmine.createSpyObj('UnitService', ['getAllUnits']);
 
     itemServiceSpy.getAllItems.and.returnValue(of(mockItems));
@@ -30,19 +38,18 @@ describe('ItemDialogComponent - Duplicate Validation', () => {
     unitServiceSpy.getAllUnits.and.returnValue(of([]));
 
     await TestBed.configureTestingModule({
-      imports: [
-        ItemDialogComponent,
-        ReactiveFormsModule,
-        NoopAnimationsModule
-      ],
+      imports: [ItemDialogComponent, ReactiveFormsModule, NoopAnimationsModule],
       providers: [
-        { provide: MatDialogRef, useValue: { close: jasmine.createSpy('close') } },
+        {
+          provide: MatDialogRef,
+          useValue: { close: jasmine.createSpy('close') },
+        },
         { provide: MAT_DIALOG_DATA, useValue: { isEdit: false } },
         { provide: ItemService, useValue: itemServiceSpy },
         { provide: CategoryService, useValue: categoryServiceSpy },
         { provide: UnitService, useValue: unitServiceSpy },
-        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } }
-      ]
+        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ItemDialogComponent);
@@ -66,17 +73,20 @@ describe('ItemDialogComponent - Duplicate Validation', () => {
     // Reconfigure for Edit Mode
     TestBed.resetTestingModule();
     const originalItem = { name: 'Apple', idCategory: 1, idUnit: 1 };
-    
+
     await TestBed.configureTestingModule({
       imports: [ItemDialogComponent, ReactiveFormsModule, NoopAnimationsModule],
       providers: [
-        { provide: MatDialogRef, useValue: { close: jasmine.createSpy('close') } },
+        {
+          provide: MatDialogRef,
+          useValue: { close: jasmine.createSpy('close') },
+        },
         { provide: MAT_DIALOG_DATA, useValue: { item: originalItem } },
         { provide: ItemService, useValue: itemServiceSpy },
         { provide: CategoryService, useValue: categoryServiceSpy },
         { provide: UnitService, useValue: unitServiceSpy },
-        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } }
-      ]
+        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } },
+      ],
     }).compileComponents();
 
     const editFixture = TestBed.createComponent(ItemDialogComponent);

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.ts
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.ts
@@ -3,9 +3,18 @@ import {
   Component,
   Inject,
   OnInit,
+  inject,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+  AbstractControl,
+  ValidationErrors,
+  ValidatorFn,
+} from '@angular/forms';
 import {
   MatDialogModule,
   MatDialogRef,
@@ -15,60 +24,46 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
-import { ItemRequestDTO } from '../../../../shared/interfaces/item.interface';
+import {
+  ItemRequestDTO,
+  ItemResponseDTO,
+} from '../../../../shared/interfaces/item.interface';
 import { CategoryService } from '../../../../shared/services/category.service';
 import { UnitService } from '../../../../shared/services/unit.service';
+import { ItemService } from '../../../../shared/services/item.service';
 import { Category } from '../../../../shared/interfaces/category.interface';
 import { Unit } from '../../../../shared/interfaces/unit.interface';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+export function duplicateNameValidator(
+  existingNames: string[],
+  originalName?: string,
+): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    if (!control.value) return null;
+    const name = control.value.trim().toLowerCase();
+    if (originalName && name === originalName.trim().toLowerCase()) return null;
+    return existingNames.some(
+      (existingName) => existingName.trim().toLowerCase() === name,
+    )
+      ? { duplicateName: true }
+      : null;
+  };
+}
 
 @Component({
   selector: 'app-item-dialog',
   standalone: true,
   imports: [
     CommonModule,
-    FormsModule,
+    ReactiveFormsModule,
     MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
     MatSelectModule,
   ],
-  template: `
-    <h2 mat-dialog-title>{{ data.item ? 'Editar' : 'Novo' }} Item</h2>
-    <mat-dialog-content>
-      <mat-form-field appearance="outline" class="w-100">
-        <mat-label>Nome</mat-label>
-        <input matInput [(ngModel)]="item.name" required />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="w-100">
-        <mat-label>Categoria</mat-label>
-        <mat-select [(ngModel)]="item.idCategory" required>
-          <mat-option *ngFor="let category of categories" [value]="category.id">
-            {{ category.name }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="w-100">
-        <mat-label>Unidade</mat-label>
-        <mat-select [(ngModel)]="item.idUnit" required>
-          <mat-option *ngFor="let unit of units" [value]="unit.id">
-            {{ unit.name }} ({{ unit.symbol }})
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button (click)="onCancel()">Cancelar</button>
-      <button
-        mat-raised-button
-        color="primary"
-        (click)="onSave()"
-        [disabled]="!item.name || !item.idCategory || !item.idUnit"
-      >
-        Salvar
-      </button>
-    </mat-dialog-actions>
-  `,
+  templateUrl: './item-dialog.component.html',
   styles: [
     `
       .w-100 {
@@ -80,13 +75,14 @@ import { Unit } from '../../../../shared/interfaces/unit.interface';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ItemDialogComponent implements OnInit {
-  item: ItemRequestDTO = {
-    name: '',
-    idCategory: 0,
-    idUnit: 0,
-  };
+  private fb = inject(FormBuilder);
+  private itemService = inject(ItemService);
+  private snackBar = inject(MatSnackBar);
+
+  itemForm: FormGroup;
   categories: Category[] = [];
   units: Unit[] = [];
+  existingItems: ItemResponseDTO[] = [];
 
   constructor(
     public dialogRef: MatDialogRef<ItemDialogComponent>,
@@ -94,14 +90,45 @@ export class ItemDialogComponent implements OnInit {
     private categoryService: CategoryService,
     private unitService: UnitService,
   ) {
+    this.itemForm = this.fb.group({
+      name: ['', [Validators.required]],
+      idCategory: [null, [Validators.required]],
+      idUnit: [null, [Validators.required]],
+    });
+
     if (data.item) {
-      this.item = { ...data.item };
+      this.itemForm.patchValue(data.item);
     }
   }
 
   ngOnInit(): void {
     this.loadCategories();
     this.loadUnits();
+    this.loadItems();
+  }
+
+  loadItems(): void {
+    this.itemService.getAllItems().subscribe({
+      next: (items) => {
+        this.existingItems = items;
+        this.updateNameValidator();
+      },
+      error: () => {
+        this.snackBar.open('Erro ao carregar itens para validação', 'Fechar', {
+          duration: 3000,
+        });
+      },
+    });
+  }
+
+  updateNameValidator(): void {
+    const names = this.existingItems.map((i) => i.name);
+    const originalName = this.data.item ? this.data.item.name : undefined;
+
+    this.itemForm
+      .get('name')
+      ?.addValidators(duplicateNameValidator(names, originalName));
+    this.itemForm.get('name')?.updateValueAndValidity();
   }
 
   loadCategories(): void {
@@ -121,6 +148,8 @@ export class ItemDialogComponent implements OnInit {
   }
 
   onSave(): void {
-    this.dialogRef.close(this.item);
+    if (this.itemForm.valid) {
+      this.dialogRef.close(this.itemForm.value);
+    }
   }
 }

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.ts
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.ts
@@ -1,14 +1,13 @@
 import {
-  ChangeDetectionStrategy,
   Component,
-  Inject,
   OnInit,
   inject,
+  signal,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormBuilder,
-  FormGroup,
   ReactiveFormsModule,
   Validators,
   AbstractControl,
@@ -75,33 +74,28 @@ export function duplicateNameValidator(
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ItemDialogComponent implements OnInit {
-  private fb = inject(FormBuilder);
-  private itemService = inject(ItemService);
-  private snackBar = inject(MatSnackBar);
+  private readonly fb = inject(FormBuilder);
+  private readonly itemService = inject(ItemService);
+  private readonly categoryService = inject(CategoryService);
+  private readonly unitService = inject(UnitService);
+  private readonly snackBar = inject(MatSnackBar);
+  readonly dialogRef = inject(MatDialogRef<ItemDialogComponent>);
+  readonly data = inject(MAT_DIALOG_DATA) as { item?: ItemRequestDTO };
 
-  itemForm: FormGroup;
-  categories: Category[] = [];
-  units: Unit[] = [];
-  existingItems: ItemResponseDTO[] = [];
+  readonly itemForm = this.fb.group({
+    name: ['', [Validators.required]],
+    idCategory: [null as number | null, [Validators.required]],
+    idUnit: [null as number | null, [Validators.required]],
+  });
 
-  constructor(
-    public dialogRef: MatDialogRef<ItemDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: { item?: ItemRequestDTO },
-    private categoryService: CategoryService,
-    private unitService: UnitService,
-  ) {
-    this.itemForm = this.fb.group({
-      name: ['', [Validators.required]],
-      idCategory: [null, [Validators.required]],
-      idUnit: [null, [Validators.required]],
-    });
-
-    if (data.item) {
-      this.itemForm.patchValue(data.item);
-    }
-  }
+  readonly categories = signal<Category[]>([]);
+  readonly units = signal<Unit[]>([]);
+  readonly existingItems = signal<ItemResponseDTO[]>([]);
 
   ngOnInit(): void {
+    if (this.data.item) {
+      this.itemForm.patchValue(this.data.item);
+    }
     this.loadCategories();
     this.loadUnits();
     this.loadItems();
@@ -110,7 +104,7 @@ export class ItemDialogComponent implements OnInit {
   loadItems(): void {
     this.itemService.getAllItems().subscribe({
       next: (items) => {
-        this.existingItems = items;
+        this.existingItems.set(items);
         this.updateNameValidator();
       },
       error: () => {
@@ -122,7 +116,7 @@ export class ItemDialogComponent implements OnInit {
   }
 
   updateNameValidator(): void {
-    const names = this.existingItems.map((i) => i.name);
+    const names = this.existingItems().map((i) => i.name);
     const originalName = this.data.item ? this.data.item.name : undefined;
 
     this.itemForm
@@ -133,13 +127,13 @@ export class ItemDialogComponent implements OnInit {
 
   loadCategories(): void {
     this.categoryService.getAllCategories().subscribe((categories) => {
-      this.categories = categories;
+      this.categories.set(categories);
     });
   }
 
   loadUnits(): void {
     this.unitService.getAllUnits().subscribe((units) => {
-      this.units = units;
+      this.units.set(units);
     });
   }
 

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.ts
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.ts
@@ -63,14 +63,7 @@ export function duplicateNameValidator(
     MatSelectModule,
   ],
   templateUrl: './item-dialog.component.html',
-  styles: [
-    `
-      .w-100 {
-        width: 100%;
-        margin-bottom: 1rem;
-      }
-    `,
-  ],
+  styleUrls: ['./item-dialog.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ItemDialogComponent implements OnInit {

--- a/frontend/src/app/list/components/shopping-list/list-dialog/list-dialog.component.html
+++ b/frontend/src/app/list/components/shopping-list/list-dialog/list-dialog.component.html
@@ -1,0 +1,18 @@
+<h2 mat-dialog-title>{{ data.list ? "Editar" : "Nova" }} Lista</h2>
+<mat-dialog-content>
+  <mat-form-field appearance="outline" class="w-100">
+    <mat-label>Nome</mat-label>
+    <input matInput [(ngModel)]="list.name" required />
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Cancelar</button>
+  <button
+    mat-raised-button
+    color="primary"
+    (click)="onSave()"
+    [disabled]="!list.name"
+  >
+    Salvar
+  </button>
+</mat-dialog-actions>

--- a/frontend/src/app/list/components/shopping-list/list-dialog/list-dialog.component.scss
+++ b/frontend/src/app/list/components/shopping-list/list-dialog/list-dialog.component.scss
@@ -1,0 +1,4 @@
+.w-100 {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/frontend/src/app/list/components/shopping-list/list-dialog/list-dialog.component.ts
+++ b/frontend/src/app/list/components/shopping-list/list-dialog/list-dialog.component.ts
@@ -22,34 +22,8 @@ import { ShoppingListRequestDTO } from '../../../../shared/interfaces/shopping-l
     MatInputModule,
     MatButtonModule,
   ],
-  template: `
-    <h2 mat-dialog-title>{{ data.list ? 'Editar' : 'Nova' }} Lista</h2>
-    <mat-dialog-content>
-      <mat-form-field appearance="outline" class="w-100">
-        <mat-label>Nome</mat-label>
-        <input matInput [(ngModel)]="list.name" required />
-      </mat-form-field>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button (click)="onCancel()">Cancelar</button>
-      <button
-        mat-raised-button
-        color="primary"
-        (click)="onSave()"
-        [disabled]="!list.name"
-      >
-        Salvar
-      </button>
-    </mat-dialog-actions>
-  `,
-  styles: [
-    `
-      .w-100 {
-        width: 100%;
-        margin-bottom: 1rem;
-      }
-    `,
-  ],
+  templateUrl: './list-dialog.component.html',
+  styleUrls: ['./list-dialog.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ListDialogComponent {

--- a/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.html
+++ b/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.html
@@ -1,0 +1,22 @@
+<h2 mat-dialog-title>{{ data.unit ? "Editar" : "Nova" }} Unidade</h2>
+<mat-dialog-content>
+  <mat-form-field appearance="outline" class="w-100">
+    <mat-label>Nome</mat-label>
+    <input matInput [(ngModel)]="unit.name" required />
+  </mat-form-field>
+  <mat-form-field appearance="outline" class="w-100">
+    <mat-label>Símbolo</mat-label>
+    <input matInput [(ngModel)]="unit.symbol" required />
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Cancelar</button>
+  <button
+    mat-raised-button
+    color="primary"
+    (click)="onSave()"
+    [disabled]="!unit.name || !unit.symbol"
+  >
+    Salvar
+  </button>
+</mat-dialog-actions>

--- a/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.html
+++ b/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.html
@@ -1,22 +1,33 @@
 <h2 mat-dialog-title>{{ data.unit ? "Editar" : "Nova" }} Unidade</h2>
-<mat-dialog-content>
-  <mat-form-field appearance="outline" class="w-100">
-    <mat-label>Nome</mat-label>
-    <input matInput [(ngModel)]="unit.name" required />
-  </mat-form-field>
-  <mat-form-field appearance="outline" class="w-100">
-    <mat-label>Símbolo</mat-label>
-    <input matInput [(ngModel)]="unit.symbol" required />
-  </mat-form-field>
-</mat-dialog-content>
-<mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()">Cancelar</button>
-  <button
-    mat-raised-button
-    color="primary"
-    (click)="onSave()"
-    [disabled]="!unit.name || !unit.symbol"
-  >
-    Salvar
-  </button>
-</mat-dialog-actions>
+<form [formGroup]="unitForm" (ngSubmit)="onSave()">
+  <mat-dialog-content>
+    <mat-form-field appearance="outline" class="w-100">
+      <mat-label>Nome</mat-label>
+      <input matInput formControlName="name" required />
+      <mat-error *ngIf="unitForm.get('name')?.hasError('required')">
+        O nome é obrigatório
+      </mat-error>
+      <mat-error *ngIf="unitForm.get('name')?.hasError('duplicateName')">
+        Esta unidade já existe
+      </mat-error>
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="w-100">
+      <mat-label>Símbolo</mat-label>
+      <input matInput formControlName="symbol" required />
+      <mat-error *ngIf="unitForm.get('symbol')?.hasError('required')">
+        O símbolo é obrigatório
+      </mat-error>
+    </mat-form-field>
+  </mat-dialog-content>
+  <mat-dialog-actions align="end">
+    <button type="button" mat-button (click)="onCancel()">Cancelar</button>
+    <button
+      type="submit"
+      mat-raised-button
+      color="primary"
+      [disabled]="unitForm.invalid"
+    >
+      Salvar
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.scss
+++ b/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.scss
@@ -1,0 +1,4 @@
+.w-100 {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
+++ b/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
@@ -112,7 +112,10 @@ export class UnitDialogComponent implements OnInit {
 
   onSave(): void {
     if (this.unitForm.valid) {
-      this.dialogRef.close(this.unitForm.value);
+      this.dialogRef.close({
+        ...this.data.unit,
+        ...this.unitForm.value,
+      });
     }
   }
 }

--- a/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
+++ b/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
@@ -1,6 +1,20 @@
-import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Inject,
+  OnInit,
+  inject,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+  AbstractControl,
+  ValidationErrors,
+  ValidatorFn,
+} from '@angular/forms';
 import {
   MatDialogModule,
   MatDialogRef,
@@ -10,13 +24,31 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { Unit } from '../../../../shared/interfaces/unit.interface';
+import { UnitService } from '../../../../shared/services/unit.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+export function duplicateNameValidator(
+  existingNames: string[],
+  originalName?: string,
+): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    if (!control.value) return null;
+    const name = control.value.trim().toLowerCase();
+    if (originalName && name === originalName.trim().toLowerCase()) return null;
+    return existingNames.some(
+      (existingName) => existingName.trim().toLowerCase() === name,
+    )
+      ? { duplicateName: true }
+      : null;
+  };
+}
 
 @Component({
   selector: 'app-unit-dialog',
   standalone: true,
   imports: [
     CommonModule,
-    FormsModule,
+    ReactiveFormsModule,
     MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
@@ -25,14 +57,35 @@ import { Unit } from '../../../../shared/interfaces/unit.interface';
   template: `
     <h2 mat-dialog-title>{{ data.unit ? 'Editar' : 'Nova' }} Unidade</h2>
     <mat-dialog-content>
-      <mat-form-field appearance="outline" class="w-100">
-        <mat-label>Nome</mat-label>
-        <input matInput [(ngModel)]="unit.name" required />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="w-100">
-        <mat-label>Símbolo</mat-label>
-        <input matInput [(ngModel)]="unit.symbol" required />
-      </mat-form-field>
+      <form [formGroup]="unitForm">
+        <mat-form-field appearance="outline" class="w-100">
+          <mat-label>Nome</mat-label>
+          <input
+            matInput
+            formControlName="name"
+            placeholder="Ex: Quilograma"
+            required
+          />
+          <mat-error *ngIf="unitForm.get('name')?.hasError('required')">
+            Nome é obrigatório
+          </mat-error>
+          <mat-error *ngIf="unitForm.get('name')?.hasError('duplicateName')">
+            Já existe uma unidade com este nome
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field appearance="outline" class="w-100">
+          <mat-label>Símbolo</mat-label>
+          <input
+            matInput
+            formControlName="symbol"
+            placeholder="Ex: kg"
+            required
+          />
+          <mat-error *ngIf="unitForm.get('symbol')?.hasError('required')">
+            Símbolo é obrigatório
+          </mat-error>
+        </mat-form-field>
+      </form>
     </mat-dialog-content>
     <mat-dialog-actions align="end">
       <button mat-button (click)="onCancel()">Cancelar</button>
@@ -40,7 +93,7 @@ import { Unit } from '../../../../shared/interfaces/unit.interface';
         mat-raised-button
         color="primary"
         (click)="onSave()"
-        [disabled]="!unit.name || !unit.symbol"
+        [disabled]="unitForm.invalid"
       >
         Salvar
       </button>
@@ -56,19 +109,54 @@ import { Unit } from '../../../../shared/interfaces/unit.interface';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class UnitDialogComponent {
-  unit: Unit = {
-    name: '',
-    symbol: '',
-  };
+export class UnitDialogComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private unitService = inject(UnitService);
+  private snackBar = inject(MatSnackBar);
+
+  unitForm: FormGroup;
+  existingUnits: Unit[] = [];
 
   constructor(
     public dialogRef: MatDialogRef<UnitDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: { unit?: Unit },
   ) {
+    this.unitForm = this.fb.group({
+      name: ['', [Validators.required]],
+      symbol: ['', [Validators.required]],
+    });
+
     if (data.unit) {
-      this.unit = { ...data.unit };
+      this.unitForm.patchValue(data.unit);
     }
+  }
+
+  ngOnInit(): void {
+    this.loadUnits();
+  }
+
+  loadUnits(): void {
+    this.unitService.getAllUnits().subscribe({
+      next: (units) => {
+        this.existingUnits = units;
+        this.updateNameValidator();
+      },
+      error: () => {
+        this.snackBar.open('Erro ao carregar unidades para validação', 'Fechar', {
+          duration: 3000,
+        });
+      },
+    });
+  }
+
+  updateNameValidator(): void {
+    const names = this.existingUnits.map((u) => u.name);
+    const originalName = this.data.unit ? this.data.unit.name : undefined;
+
+    this.unitForm
+      .get('name')
+      ?.addValidators(duplicateNameValidator(names, originalName));
+    this.unitForm.get('name')?.updateValueAndValidity();
   }
 
   onCancel(): void {
@@ -76,6 +164,8 @@ export class UnitDialogComponent {
   }
 
   onSave(): void {
-    this.dialogRef.close(this.unit);
+    if (this.unitForm.valid) {
+      this.dialogRef.close(this.unitForm.value);
+    }
   }
 }

--- a/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
+++ b/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
@@ -1,14 +1,13 @@
 import {
-  ChangeDetectionStrategy,
   Component,
-  Inject,
   OnInit,
   inject,
+  signal,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormBuilder,
-  FormGroup,
   ReactiveFormsModule,
   Validators,
   AbstractControl,
@@ -55,9 +54,9 @@ export function duplicateNameValidator(
     MatButtonModule,
   ],
   template: `
-    <h2 mat-dialog-title>{{ data.unit ? 'Editar' : 'Nova' }} Unidade</h2>
-    <mat-dialog-content>
-      <form [formGroup]="unitForm">
+    <form [formGroup]="unitForm" (ngSubmit)="onSave()">
+      <h2 mat-dialog-title>{{ data.unit ? "Editar" : "Nova" }} Unidade</h2>
+      <mat-dialog-content>
         <mat-form-field appearance="outline" class="w-100">
           <mat-label>Nome</mat-label>
           <input
@@ -66,12 +65,11 @@ export function duplicateNameValidator(
             placeholder="Ex: Quilograma"
             required
           />
-          <mat-error *ngIf="unitForm.get('name')?.hasError('required')">
-            Nome é obrigatório
-          </mat-error>
-          <mat-error *ngIf="unitForm.get('name')?.hasError('duplicateName')">
-            Já existe uma unidade com este nome
-          </mat-error>
+          @if (unitForm.get('name')?.hasError('required')) {
+          <mat-error> Nome é obrigatório </mat-error>
+          } @if (unitForm.get('name')?.hasError('duplicateName')) {
+          <mat-error> Já existe uma unidade com este nome </mat-error>
+          }
         </mat-form-field>
         <mat-form-field appearance="outline" class="w-100">
           <mat-label>Símbolo</mat-label>
@@ -81,23 +79,23 @@ export function duplicateNameValidator(
             placeholder="Ex: kg"
             required
           />
-          <mat-error *ngIf="unitForm.get('symbol')?.hasError('required')">
-            Símbolo é obrigatório
-          </mat-error>
+          @if (unitForm.get('symbol')?.hasError('required')) {
+          <mat-error> Símbolo é obrigatório </mat-error>
+          }
         </mat-form-field>
-      </form>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button (click)="onCancel()">Cancelar</button>
-      <button
-        mat-raised-button
-        color="primary"
-        (click)="onSave()"
-        [disabled]="unitForm.invalid"
-      >
-        Salvar
-      </button>
-    </mat-dialog-actions>
+      </mat-dialog-content>
+      <mat-dialog-actions align="end">
+        <button mat-button type="button" (click)="onCancel()">Cancelar</button>
+        <button
+          mat-raised-button
+          color="primary"
+          type="submit"
+          [disabled]="unitForm.invalid"
+        >
+          Salvar
+        </button>
+      </mat-dialog-actions>
+    </form>
   `,
   styles: [
     `
@@ -110,47 +108,46 @@ export function duplicateNameValidator(
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UnitDialogComponent implements OnInit {
-  private fb = inject(FormBuilder);
-  private unitService = inject(UnitService);
-  private snackBar = inject(MatSnackBar);
+  private readonly fb = inject(FormBuilder);
+  private readonly unitService = inject(UnitService);
+  private readonly snackBar = inject(MatSnackBar);
+  readonly dialogRef = inject(MatDialogRef<UnitDialogComponent>);
+  readonly data = inject(MAT_DIALOG_DATA) as { unit?: Unit };
 
-  unitForm: FormGroup;
-  existingUnits: Unit[] = [];
+  readonly unitForm = this.fb.group({
+    name: ['', [Validators.required]],
+    symbol: ['', [Validators.required]],
+  });
 
-  constructor(
-    public dialogRef: MatDialogRef<UnitDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: { unit?: Unit },
-  ) {
-    this.unitForm = this.fb.group({
-      name: ['', [Validators.required]],
-      symbol: ['', [Validators.required]],
-    });
-
-    if (data.unit) {
-      this.unitForm.patchValue(data.unit);
-    }
-  }
+  readonly existingUnits = signal<Unit[]>([]);
 
   ngOnInit(): void {
+    if (this.data.unit) {
+      this.unitForm.patchValue(this.data.unit);
+    }
     this.loadUnits();
   }
 
   loadUnits(): void {
     this.unitService.getAllUnits().subscribe({
       next: (units) => {
-        this.existingUnits = units;
+        this.existingUnits.set(units);
         this.updateNameValidator();
       },
       error: () => {
-        this.snackBar.open('Erro ao carregar unidades para validação', 'Fechar', {
-          duration: 3000,
-        });
+        this.snackBar.open(
+          'Erro ao carregar unidades para validação',
+          'Fechar',
+          {
+            duration: 3000,
+          },
+        );
       },
     });
   }
 
   updateNameValidator(): void {
-    const names = this.existingUnits.map((u) => u.name);
+    const names = this.existingUnits().map((u) => u.name);
     const originalName = this.data.unit ? this.data.unit.name : undefined;
 
     this.unitForm

--- a/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
+++ b/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
@@ -55,7 +55,7 @@ export function duplicateNameValidator(
   ],
   template: `
     <form [formGroup]="unitForm" (ngSubmit)="onSave()">
-      <h2 mat-dialog-title>{{ data.unit ? "Editar" : "Nova" }} Unidade</h2>
+      <h2 mat-dialog-title>{{ data.unit ? 'Editar' : 'Nova' }} Unidade</h2>
       <mat-dialog-content>
         <mat-form-field appearance="outline" class="w-100">
           <mat-label>Nome</mat-label>
@@ -66,9 +66,10 @@ export function duplicateNameValidator(
             required
           />
           @if (unitForm.get('name')?.hasError('required')) {
-          <mat-error> Nome é obrigatório </mat-error>
-          } @if (unitForm.get('name')?.hasError('duplicateName')) {
-          <mat-error> Já existe uma unidade com este nome </mat-error>
+            <mat-error> Nome é obrigatório </mat-error>
+          }
+          @if (unitForm.get('name')?.hasError('duplicateName')) {
+            <mat-error> Já existe uma unidade com este nome </mat-error>
           }
         </mat-form-field>
         <mat-form-field appearance="outline" class="w-100">
@@ -80,7 +81,7 @@ export function duplicateNameValidator(
             required
           />
           @if (unitForm.get('symbol')?.hasError('required')) {
-          <mat-error> Símbolo é obrigatório </mat-error>
+            <mat-error> Símbolo é obrigatório </mat-error>
           }
         </mat-form-field>
       </mat-dialog-content>

--- a/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
+++ b/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
@@ -53,59 +53,8 @@ export function duplicateNameValidator(
     MatInputModule,
     MatButtonModule,
   ],
-  template: `
-    <form [formGroup]="unitForm" (ngSubmit)="onSave()">
-      <h2 mat-dialog-title>{{ data.unit ? 'Editar' : 'Nova' }} Unidade</h2>
-      <mat-dialog-content>
-        <mat-form-field appearance="outline" class="w-100">
-          <mat-label>Nome</mat-label>
-          <input
-            matInput
-            formControlName="name"
-            placeholder="Ex: Quilograma"
-            required
-          />
-          @if (unitForm.get('name')?.hasError('required')) {
-            <mat-error> Nome é obrigatório </mat-error>
-          }
-          @if (unitForm.get('name')?.hasError('duplicateName')) {
-            <mat-error> Já existe uma unidade com este nome </mat-error>
-          }
-        </mat-form-field>
-        <mat-form-field appearance="outline" class="w-100">
-          <mat-label>Símbolo</mat-label>
-          <input
-            matInput
-            formControlName="symbol"
-            placeholder="Ex: kg"
-            required
-          />
-          @if (unitForm.get('symbol')?.hasError('required')) {
-            <mat-error> Símbolo é obrigatório </mat-error>
-          }
-        </mat-form-field>
-      </mat-dialog-content>
-      <mat-dialog-actions align="end">
-        <button mat-button type="button" (click)="onCancel()">Cancelar</button>
-        <button
-          mat-raised-button
-          color="primary"
-          type="submit"
-          [disabled]="unitForm.invalid"
-        >
-          Salvar
-        </button>
-      </mat-dialog-actions>
-    </form>
-  `,
-  styles: [
-    `
-      .w-100 {
-        width: 100%;
-        margin-bottom: 1rem;
-      }
-    `,
-  ],
+  templateUrl: './unit-dialog.component.html',
+  styleUrls: ['./unit-dialog.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UnitDialogComponent implements OnInit {


### PR DESCRIPTION
Fix #79, #38 

## Summary (Copilot)

This pull request refactors and improves the category and item dialog components, focusing on better form validation and maintainability. The main changes include moving templates and styles to dedicated files, introducing robust duplicate name validation for both categories and items, and adding comprehensive unit tests to ensure correct behavior. These improvements enhance user experience by providing clearer validation feedback and prevent duplicate entries.

**Category Dialog Improvements:**

* Moved the template and styles for `CategoryDialogComponent` to separate files (`category-dialog.component.html` and `category-dialog.component.scss`) for better maintainability and readability. [[1]](diffhunk://#diff-d50f0538cd28533024a6a593bc01c330c2a68439c94b26678f75c0e0539528cdR1-R18) [[2]](diffhunk://#diff-7d686d1262a95ecd5ea34954d38d80e436a06cae1e4f0d528186402766e312ecR1-R4) [[3]](diffhunk://#diff-baa456edfcdf9abe69084ed8a91f19370f52d52ac85abed13e0a5daf27269a7bL25-R26)
* Refactored the component to use reactive forms, added a custom `duplicateNameValidator` to prevent duplicate category names (case-insensitive and whitespace-trimmed), and ensured validation works correctly in both create and edit modes. [[1]](diffhunk://#diff-b01b9485d7557f06c1f7df433d2c06243ab5d359c87b45e6a5275d5fef7f86eaL1-R43) [[2]](diffhunk://#diff-b01b9485d7557f06c1f7df433d2c06243ab5d359c87b45e6a5275d5fef7f86eaL33-R129)
* Added unit tests to verify duplicate name validation logic and form behavior in various scenarios.

**Item Dialog Improvements:**

* Migrated the template and styles for `ItemDialogComponent` to dedicated files (`item-dialog.component.html` and `item-dialog.component.scss`), matching the structure used for categories. [[1]](diffhunk://#diff-f90f1cccdf646375cd4a7b74af959a1506b60cc27b3b2d642d5d20c3a4e68c21R1-R59) [[2]](diffhunk://#diff-7d686d1262a95ecd5ea34954d38d80e436a06cae1e4f0d528186402766e312ecR1-R4)
* Implemented duplicate name validation for items, ensuring users cannot add items with names that already exist (case-insensitive and whitespace-trimmed), and improved form feedback.
* Added unit tests to confirm duplicate name validation and correct form behavior in create and edit scenarios.