### PR TITLE
feat(frontend): translate UI and logs to English (#106)

### DIFF
--- a/frontend/src/app/auth/login/login.component.html
+++ b/frontend/src/app/auth/login/login.component.html
@@ -13,26 +13,26 @@
               matInput
               type="email"
               formControlName="email"
-              placeholder="Seu email"
+              placeholder="Your email"
             />
 
             @if (
               loginForm.get("email")?.hasError("required") &&
               loginForm.get("email")?.touched
             ) {
-              <mat-error> Email é obrigatório </mat-error>
+              <mat-error> Email is required </mat-error>
             }
 
             @if (
               loginForm.get("email")?.hasError("email") &&
               !loginForm.get("email")?.hasError("required")
             ) {
-              <mat-error> Email inválido </mat-error>
+              <mat-error> Email is invalid </mat-error>
             }
           </mat-form-field>
 
           <mat-form-field appearance="outline" class="form-field">
-            <mat-label>Senha</mat-label>
+            <mat-label>Password</mat-label>
             <input
               matInput
               [type]="hidePassword() ? 'password' : 'text'"
@@ -53,7 +53,7 @@
               loginForm.get("password")?.hasError("required") &&
               loginForm.get("password")?.touched
             ) {
-              <mat-error> Senha é obrigatória </mat-error>
+              <mat-error> Password is required </mat-error>
             }
           </mat-form-field>
 
@@ -67,7 +67,7 @@
               @if (isLoading()) {
                 <mat-spinner diameter="24"></mat-spinner>
               } @else {
-                Entrar
+                Sign In
               }
             </button>
           </div>
@@ -75,8 +75,8 @@
       </mat-card-content>
 
       <mat-card-actions class="login-actions">
-        <span>Não possui uma conta?</span>
-        <a mat-button color="primary" routerLink="/signup">Cadastre-se</a>
+        <span>Don't have an account?</span>
+        <a mat-button color="primary" routerLink="/signup">Sign Up</a>
       </mat-card-actions>
     </mat-card>
   </div>

--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -76,8 +76,8 @@ export class LoginComponent {
           console.error('Login error:', error);
           this.snackBar.open(
             error.message ||
-              'Falha ao fazer login. Verifique suas credenciais.',
-            'Fechar',
+              'Failed to sign in. Please check your credentials.',
+            'Close',
             {
               duration: 5000,
               panelClass: ['error-snackbar'],

--- a/frontend/src/app/auth/signup/signup.component.html
+++ b/frontend/src/app/auth/signup/signup.component.html
@@ -2,23 +2,23 @@
   <div class="signup-container">
     <mat-card appearance="outlined">
       <mat-card-header>
-        <mat-card-title>Criar Conta</mat-card-title>
+        <mat-card-title>Create Account</mat-card-title>
       </mat-card-header>
 
       <mat-card-content>
         <form [formGroup]="signupForm" (ngSubmit)="onSubmit()">
           <mat-form-field appearance="outline" class="form-field">
-            <mat-label>Nome Completo</mat-label>
+            <mat-label>Full Name</mat-label>
             <input
               matInput
               formControlName="fullName"
-              placeholder="Seu nome completo"
+              placeholder="Your full name"
             />
             @if (
               signupForm.get("fullName")?.hasError("required") &&
               signupForm.get("fullName")?.touched
             ) {
-              <mat-error>Nome completo é obrigatório</mat-error>
+              <mat-error>Full name is required</mat-error>
             }
           </mat-form-field>
 
@@ -28,24 +28,24 @@
               matInput
               type="email"
               formControlName="email"
-              placeholder="Seu email"
+              placeholder="Your email"
             />
             @if (
               signupForm.get("email")?.hasError("required") &&
               signupForm.get("email")?.touched
             ) {
-              <mat-error>Email é obrigatório</mat-error>
+              <mat-error>Email is required</mat-error>
             }
             @if (
               signupForm.get("email")?.hasError("email") &&
               !signupForm.get("email")?.hasError("required")
             ) {
-              <mat-error>Email é inválido</mat-error>
+              <mat-error>Email is invalid</mat-error>
             }
           </mat-form-field>
 
           <mat-form-field appearance="outline" class="form-field">
-            <mat-label>Senha</mat-label>
+            <mat-label>Password</mat-label>
             <input
               matInput
               [type]="hidePassword() ? 'password' : 'text'"
@@ -65,13 +65,13 @@
               signupForm.get("password")?.hasError("required") &&
               signupForm.get("password")?.touched
             ) {
-              <mat-error>Senha é obrigatória</mat-error>
+              <mat-error>Password is required</mat-error>
             }
             @if (
               signupForm.get("password")?.hasError("minlength") &&
               !signupForm.get("password")?.hasError("required")
             ) {
-              <mat-error>A senha deve conter pelo menos 6 caracteres</mat-error>
+              <mat-error>Password must be at least 6 characters long</mat-error>
             }
           </mat-form-field>
 
@@ -85,7 +85,7 @@
               @if (isLoading()) {
                 <mat-spinner diameter="24"></mat-spinner>
               } @else {
-                Criar Conta
+                Create Account
               }
             </button>
           </div>
@@ -93,8 +93,8 @@
       </mat-card-content>
 
       <mat-card-actions class="login-actions">
-        <span>Já possui uma conta?</span>
-        <a mat-button color="primary" routerLink="/login">Entrar</a>
+        <span>Already have an account?</span>
+        <a mat-button color="primary" routerLink="/login">Sign In</a>
       </mat-card-actions>
     </mat-card>
   </div>

--- a/frontend/src/app/auth/signup/signup.component.ts
+++ b/frontend/src/app/auth/signup/signup.component.ts
@@ -73,7 +73,7 @@ export class SignupComponent {
       .pipe(finalize(() => this.isLoading.set(false)))
       .subscribe({
         next: () => {
-          this.snackBar.open('Cadastro realizado com sucesso!', 'Fechar', {
+          this.snackBar.open('Account created successfully!', 'Close', {
             duration: 3000,
           });
           this.router.navigate(['/login']);
@@ -81,8 +81,8 @@ export class SignupComponent {
         error: (error) => {
           console.error('Signup error:', error);
           this.snackBar.open(
-            'Falha ao realizar cadastro. Tente novamente.',
-            'Fechar',
+            'Failed to create account. Please try again.',
+            'Close',
             { duration: 5000 },
           );
         },

--- a/frontend/src/app/layout/landing/landing.component.html
+++ b/frontend/src/app/layout/landing/landing.component.html
@@ -3,16 +3,16 @@
     <mat-card class="hero-card mat-elevation-z8">
       <mat-card-content>
         <div class="hero-content">
-          <h1 class="mat-display-2">Bem-vindo ao ShoppMate</h1>
-          <p class="mat-h2">Organize suas compras de forma inteligente</p>
+          <h1 class="mat-display-2">Welcome to ShoppMate</h1>
+          <p class="mat-h2">Organize your purchases in an intelligent way</p>
           <div class="cta-buttons">
             <a mat-raised-button color="primary" routerLink="/signup">
               <mat-icon>rocket_launch</mat-icon>
-              Começar Agora
+              Get Started Now
             </a>
             <a mat-stroked-button routerLink="/login">
               <mat-icon>login</mat-icon>
-              Já tenho uma conta
+              Already have an account?
             </a>
           </div>
         </div>
@@ -24,48 +24,48 @@
     <mat-card class="feature-card" appearance="outlined">
       <mat-card-header>
         <mat-icon mat-card-avatar color="primary">list_alt</mat-icon>
-        <mat-card-title>Listas Compartilhadas</mat-card-title>
+        <mat-card-title>Shared Lists</mat-card-title>
       </mat-card-header>
       <mat-card-content>
         <p class="mat-body-1">
-          Crie e compartilhe listas de compras com família e amigos. Mantenha
-          todos atualizados em tempo real.
+          Create and share shopping lists with family and friends. Keep everyone
+          updated in real-time.
         </p>
       </mat-card-content>
       <mat-card-actions align="end">
-        <button mat-button color="primary">SAIBA MAIS</button>
+        <button mat-button color="primary">Learn More</button>
       </mat-card-actions>
     </mat-card>
 
     <mat-card class="feature-card" appearance="outlined">
       <mat-card-header>
         <mat-icon mat-card-avatar color="primary">category</mat-icon>
-        <mat-card-title>Categorias Inteligentes</mat-card-title>
+        <mat-card-title>Smart Categories</mat-card-title>
       </mat-card-header>
       <mat-card-content>
         <p class="mat-body-1">
-          Organize seus itens por categorias para comprar de forma mais
-          eficiente e nunca esquecer nada.
+          Organize your items by categories for more efficient shopping and
+          never forget anything.
         </p>
       </mat-card-content>
       <mat-card-actions align="end">
-        <button mat-button color="primary">SAIBA MAIS</button>
+        <button mat-button color="primary">Learn More</button>
       </mat-card-actions>
     </mat-card>
 
     <mat-card class="feature-card" appearance="outlined">
       <mat-card-header>
         <mat-icon mat-card-avatar color="primary">group</mat-icon>
-        <mat-card-title>Colaboração em Tempo Real</mat-card-title>
+        <mat-card-title>Real-time Collaboration</mat-card-title>
       </mat-card-header>
       <mat-card-content>
         <p class="mat-body-1">
-          Trabalhe em equipe para manter suas listas atualizadas. Todos na mesma
-          página, sempre.
+          Work together to keep your lists updated. Everyone on the same page,
+          always.
         </p>
       </mat-card-content>
       <mat-card-actions align="end">
-        <button mat-button color="primary">SAIBA MAIS</button>
+        <button mat-button color="primary">Learn More</button>
       </mat-card-actions>
     </mat-card>
   </section>
@@ -73,26 +73,26 @@
   <section class="how-it-works">
     <mat-card class="steps-card">
       <mat-card-header>
-        <mat-card-title class="mat-h1">Como Funciona</mat-card-title>
+        <mat-card-title class="mat-h1">How It Works</mat-card-title>
       </mat-card-header>
       <mat-card-content>
         <mat-stepper orientation="vertical">
           <mat-step>
-            <ng-template matStepLabel>Crie sua conta</ng-template>
+            <ng-template matStepLabel>Create Your Account</ng-template>
             <p class="mat-body-1">
-              Comece criando sua conta gratuita em poucos segundos.
+              Start by creating your free account in a few seconds.
             </p>
           </mat-step>
           <mat-step>
-            <ng-template matStepLabel>Crie suas listas</ng-template>
+            <ng-template matStepLabel>Create Your Lists</ng-template>
             <p class="mat-body-1">
-              Organize suas compras em listas práticas e intuitivas.
+              Organize your purchases in practical and intuitive lists.
             </p>
           </mat-step>
           <mat-step>
-            <ng-template matStepLabel>Compartilhe e colabore</ng-template>
+            <ng-template matStepLabel>Share and Collaborate</ng-template>
             <p class="mat-body-1">
-              Convide família e amigos para colaborar em suas listas.
+              Invite family and friends to collaborate on your lists.
             </p>
           </mat-step>
         </mat-stepper>

--- a/frontend/src/app/layout/navbar/navbar.component.html
+++ b/frontend/src/app/layout/navbar/navbar.component.html
@@ -8,19 +8,19 @@
         <div class="nav-links" [class.hidden-mobile]="!isLargeScreen()">
           <a mat-button routerLink="/lists" routerLinkActive="active-link">
             <mat-icon>list</mat-icon>
-            <span>Minhas Listas</span>
+            <span>My Lists</span>
           </a>
           <a mat-button routerLink="/items" routerLinkActive="active-link">
             <mat-icon>shopping_basket</mat-icon>
-            <span>Itens</span>
+            <span>Items</span>
           </a>
           <a mat-button routerLink="/categories" routerLinkActive="active-link">
             <mat-icon>category</mat-icon>
-            <span>Categorias</span>
+            <span>Categories</span>
           </a>
           <a mat-button routerLink="/units" routerLinkActive="active-link">
             <mat-icon>straighten</mat-icon>
-            <span>Unidades</span>
+            <span>Units</span>
           </a>
         </div>
 
@@ -38,7 +38,7 @@
           >Login</a
         >
         <a mat-button routerLink="/signup" routerLinkActive="active-link"
-          >Cadastro</a
+          >Sign Up</a
         >
       }
     </mat-toolbar>
@@ -46,30 +46,30 @@
     <mat-menu #navMenu="matMenu">
       <a mat-menu-item routerLink="/lists">
         <mat-icon>list</mat-icon>
-        <span>Minhas Listas</span>
+        <span>My Lists</span>
       </a>
       <a mat-menu-item routerLink="/items">
         <mat-icon>shopping_basket</mat-icon>
-        <span>Itens</span>
+        <span>Items</span>
       </a>
       <a mat-menu-item routerLink="/categories">
         <mat-icon>category</mat-icon>
-        <span>Categorias</span>
+        <span>Categories</span>
       </a>
       <a mat-menu-item routerLink="/units">
         <mat-icon>straighten</mat-icon>
-        <span>Unidades</span>
+        <span>Units</span>
       </a>
     </mat-menu>
 
     <mat-menu #profileMenu="matMenu">
       <a mat-menu-item routerLink="/profile">
         <mat-icon>person</mat-icon>
-        <span>Perfil</span>
+        <span>Profile</span>
       </a>
       <button mat-menu-item (click)="logout()">
         <mat-icon>logout</mat-icon>
-        <span>Sair</span>
+        <span>Logout</span>
       </button>
     </mat-menu>
 

--- a/frontend/src/app/list/components/categories-management/categories-management.component.html
+++ b/frontend/src/app/list/components/categories-management/categories-management.component.html
@@ -1,7 +1,7 @@
 <div class="categories-container">
   <mat-card>
     <mat-card-header>
-      <mat-card-title>Gerenciamento de Categorias</mat-card-title>
+      <mat-card-title>Category Management”</mat-card-title>
     </mat-card-header>
 
     <mat-card-content>
@@ -33,7 +33,7 @@
             </div>
           } @empty {
             <div class="no-categories">
-              <p>Nenhuma categoria cadastrada</p>
+              <p>No categories registered</p>
             </div>
           }
         </div>
@@ -47,7 +47,7 @@
         (click)="openNewCategoryDialog()"
       >
         <mat-icon>add</mat-icon>
-        Nova Categoria
+        New Category
       </button>
     </mat-card-actions>
   </mat-card>

--- a/frontend/src/app/list/components/categories-management/categories-management.component.ts
+++ b/frontend/src/app/list/components/categories-management/categories-management.component.ts
@@ -87,20 +87,20 @@ export class CategoriesManagementComponent implements OnInit {
   deleteCategory(id: number): void {
     this.confirmDialog
       .open({
-        title: 'Excluir categoria',
-        message: 'Tem certeza que deseja excluir esta categoria?',
-        confirmText: 'Excluir',
+        title: 'Delete category',
+        message: 'Are you sure you want to delete this category?',
+        confirmText: 'Delete',
       })
       .subscribe((confirmed) => {
         if (!confirmed) return;
 
         this.categoryService.deleteCategory(id).subscribe({
           next: () => {
-            this.feedback.success('Categoria excluida com sucesso');
+            this.feedback.success('Category deleted successfully');
             this.loadCategories();
           },
           error: () => {
-            this.feedback.error('Erro ao excluir categoria');
+            this.feedback.error('Error deleting category');
           },
         });
       });

--- a/frontend/src/app/list/components/category-dialog/category-dialog.component.html
+++ b/frontend/src/app/list/components/category-dialog/category-dialog.component.html
@@ -1,37 +1,37 @@
 <form [formGroup]="categoryForm" (ngSubmit)="onSubmit()">
   <h2 mat-dialog-title>
-    {{ isEdit() ? "Editar Categoria" : "Nova Categoria" }}
+    {{ isEdit() ? "Update" : "Create" }}
   </h2>
 
   <mat-dialog-content>
     <mat-form-field appearance="outline" class="w-100">
-      <mat-label>Nome da Categoria</mat-label>
+      <mat-label>Category Name</mat-label>
       <input
         matInput
         formControlName="name"
-        placeholder="Digite o nome da categoria"
+        placeholder="Enter the category name"
       />
       @if (categoryForm.get("name")?.hasError("required")) {
-        <mat-error> Nome é obrigatório </mat-error>
+        <mat-error> Name is required </mat-error>
       }
       @if (categoryForm.get("name")?.hasError("minlength")) {
-        <mat-error> Nome deve ter pelo menos 3 caracteres </mat-error>
+        <mat-error> Name must be at least 3 characters </mat-error>
       }
       @if (categoryForm.get("name")?.hasError("duplicateName")) {
-        <mat-error> Já existe uma categoria com este nome </mat-error>
+        <mat-error> A category with this name already exists </mat-error>
       }
     </mat-form-field>
   </mat-dialog-content>
 
   <mat-dialog-actions align="end">
-    <button mat-button type="button" (click)="onCancel()">Cancelar</button>
+    <button mat-button type="button" (click)="onCancel()">Cancel</button>
     <button
       mat-raised-button
       color="primary"
       type="submit"
       [disabled]="!categoryForm.valid"
     >
-      {{ isEdit() ? "Atualizar" : "Criar" }}
+      {{ isEdit() ? "Update" : "Create" }}
     </button>
   </mat-dialog-actions>
 </form>

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.html
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.html
@@ -1,24 +1,24 @@
 <form [formGroup]="itemForm" (ngSubmit)="onSave()">
-  <h2 mat-dialog-title>{{ data.item ? "Editar" : "Novo" }} Item</h2>
+  <h2 mat-dialog-title>{{ data.item ? "Edit" : "New" }} Item</h2>
   <mat-dialog-content>
     <mat-form-field appearance="outline" class="w-100">
-      <mat-label>Nome</mat-label>
+      <mat-label>Name</mat-label>
       <input
         matInput
         formControlName="name"
-        placeholder="Digite o nome do item"
+        placeholder="Enter the item name"
         required
       />
       @if (itemForm.get("name")?.hasError("required")) {
-        <mat-error> Nome é obrigatório </mat-error>
+        <mat-error> Name is required </mat-error>
       }
       @if (itemForm.get("name")?.hasError("duplicateName")) {
-        <mat-error> Já existe um item com este nome </mat-error>
+        <mat-error> An item with this name already exists </mat-error>
       }
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="w-100">
-      <mat-label>Categoria</mat-label>
+      <mat-label>Category</mat-label>
       <mat-select formControlName="idCategory" required>
         @for (category of categories(); track category.id) {
           <mat-option [value]="category.id">
@@ -27,12 +27,12 @@
         }
       </mat-select>
       @if (itemForm.get("idCategory")?.hasError("required")) {
-        <mat-error> Categoria é obrigatória </mat-error>
+        <mat-error> Category is required </mat-error>
       }
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="w-100">
-      <mat-label>Unidade</mat-label>
+      <mat-label>Unit</mat-label>
       <mat-select formControlName="idUnit" required>
         @for (unit of units(); track unit.id) {
           <mat-option [value]="unit.id">
@@ -41,19 +41,19 @@
         }
       </mat-select>
       @if (itemForm.get("idUnit")?.hasError("required")) {
-        <mat-error> Unidade é obrigatória </mat-error>
+        <mat-error> Unit is required </mat-error>
       }
     </mat-form-field>
   </mat-dialog-content>
   <mat-dialog-actions align="end">
-    <button mat-button type="button" (click)="onCancel()">Cancelar</button>
+    <button mat-button type="button" (click)="onCancel()">Cancel</button>
     <button
       mat-raised-button
       color="primary"
       type="submit"
       [disabled]="itemForm.invalid"
     >
-      Salvar
+      Save
     </button>
   </mat-dialog-actions>
 </form>

--- a/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.ts
+++ b/frontend/src/app/list/components/items-management/item-dialog/item-dialog.component.ts
@@ -107,7 +107,7 @@ export class ItemDialogComponent implements OnInit {
         this.updateNameValidator();
       },
       error: () => {
-        this.feedback.error('Erro ao carregar itens para validacao');
+        this.feedback.error('Error loading items for validation');
       },
     });
   }

--- a/frontend/src/app/list/components/items-management/items-management.component.html
+++ b/frontend/src/app/list/components/items-management/items-management.component.html
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="page-header">
-    <h1>Gerenciar Itens</h1>
+    <h1>Manage Items</h1>
   </div>
 
   @if (loading()) {
@@ -10,7 +10,7 @@
   } @else {
     <div class="add-item-container mb-3">
       <button mat-raised-button color="primary" (click)="openAddItemDialog()">
-        <mat-icon>add</mat-icon> Novo Item
+        <mat-icon>add</mat-icon> New Item
       </button>
     </div>
 
@@ -21,13 +21,13 @@
             <table mat-table [dataSource]="items" class="item-table">
               <!-- Name Column -->
               <ng-container matColumnDef="name">
-                <th mat-header-cell *matHeaderCellDef>Nome</th>
+                <th mat-header-cell *matHeaderCellDef>Name</th>
                 <td mat-cell *matCellDef="let element">{{ element.name }}</td>
               </ng-container>
 
               <!-- Category Column -->
               <ng-container matColumnDef="category">
-                <th mat-header-cell *matHeaderCellDef>Categoria</th>
+                <th mat-header-cell *matHeaderCellDef>Category</th>
                 <td mat-cell *matCellDef="let element">
                   {{ element.category.name }}
                 </td>
@@ -35,7 +35,7 @@
 
               <!-- Unit Column -->
               <ng-container matColumnDef="unit">
-                <th mat-header-cell *matHeaderCellDef>Unidade</th>
+                <th mat-header-cell *matHeaderCellDef>Unit</th>
                 <td mat-cell *matCellDef="let element">
                   {{ element.unit.symbol }}
                 </td>
@@ -43,7 +43,7 @@
 
               <!-- Actions Column -->
               <ng-container matColumnDef="actions">
-                <th mat-header-cell *matHeaderCellDef>Ações</th>
+                <th mat-header-cell *matHeaderCellDef>Actions</th>
                 <td mat-cell *matCellDef="let element">
                   <button
                     mat-icon-button
@@ -70,13 +70,13 @@
       } @else {
         <mat-card appearance="outlined" class="empty-state">
           <mat-card-content>
-            <p>Nenhum item cadastrado.</p>
+            <p>No items registered.</p>
             <button
               mat-raised-button
               color="primary"
               (click)="openAddItemDialog()"
             >
-              Cadastrar Primeiro Item
+              Register First Item
             </button>
           </mat-card-content>
         </mat-card>

--- a/frontend/src/app/list/components/items-management/items-management.component.ts
+++ b/frontend/src/app/list/components/items-management/items-management.component.ts
@@ -97,10 +97,10 @@ export class ItemsManagementComponent implements OnInit {
         this.itemService.addItem(result).subscribe({
           next: () => {
             this.loadItems();
-            this.feedback.success('Item adicionado com sucesso');
+            this.feedback.success('Item added successfully');
           },
           error: () => {
-            this.feedback.error('Erro ao adicionar item');
+            this.feedback.error('Error adding item');
           },
         });
       }
@@ -124,10 +124,10 @@ export class ItemsManagementComponent implements OnInit {
         this.itemService.updateItem(item.id, result).subscribe({
           next: () => {
             this.loadItems();
-            this.feedback.success('Item atualizado com sucesso');
+            this.feedback.success('Item updated successfully');
           },
           error: () => {
-            this.feedback.error('Erro ao atualizar item');
+            this.feedback.error('Error updating item');
           },
         });
       }
@@ -137,9 +137,9 @@ export class ItemsManagementComponent implements OnInit {
   deleteItem(item: ItemResponseDTO): void {
     this.confirmDialog
       .open({
-        title: 'Excluir item',
-        message: `Tem certeza que deseja excluir o item "${item.name}"?`,
-        confirmText: 'Excluir',
+        title: 'Delete Item',
+        message: `Are you sure you want to delete the item "${item.name}"?`,
+        confirmText: 'Delete',
       })
       .subscribe((confirmed) => {
         if (!confirmed) return;
@@ -147,10 +147,10 @@ export class ItemsManagementComponent implements OnInit {
         this.itemService.deleteItem(item.id).subscribe({
           next: () => {
             this.loadItems();
-            this.feedback.success('Item excluido com sucesso');
+            this.feedback.success('Item deleted successfully');
           },
           error: () => {
-            this.feedback.error('Erro ao excluir item');
+            this.feedback.error('Error deleting item');
           },
         });
       });

--- a/frontend/src/app/list/components/list-details/list-details.component.html
+++ b/frontend/src/app/list/components/list-details/list-details.component.html
@@ -10,7 +10,7 @@
   } @else {
     <div class="list-actions mb-3">
       <button mat-raised-button color="primary" (click)="openAddItemDialog()">
-        <mat-icon>add</mat-icon> Adicionar Item
+        <mat-icon>add</mat-icon> Add Item
       </button>
     </div>
 
@@ -36,7 +36,7 @@
 
               <!-- Quantity Column -->
               <ng-container matColumnDef="quantity">
-                <th mat-header-cell *matHeaderCellDef>Quantidade</th>
+                <th mat-header-cell *matHeaderCellDef>Quantity</th>
                 <td mat-cell *matCellDef="let element">
                   {{ element.quantity }} {{ element.item.unit.symbol }}
                 </td>
@@ -50,14 +50,14 @@
                     [checked]="element.purchased"
                     (change)="togglePurchased(element)"
                   >
-                    {{ element.purchased ? "Comprado" : "Pendente" }}
+                    {{ element.purchased ? "Purchased" : "Pending" }}
                   </mat-checkbox>
                 </td>
               </ng-container>
 
               <!-- Actions Column -->
               <ng-container matColumnDef="actions">
-                <th mat-header-cell *matHeaderCellDef>Ações</th>
+                <th mat-header-cell *matHeaderCellDef>Actions</th>
                 <td mat-cell *matCellDef="let element">
                   <button
                     mat-icon-button
@@ -85,13 +85,13 @@
     } @else {
       <mat-card appearance="outlined" class="empty-list">
         <mat-card-content>
-          <p>Esta lista não possui itens.</p>
+          <p>This list does not have any items.</p>
           <button
             mat-raised-button
             color="primary"
             (click)="openAddItemDialog()"
           >
-            Adicionar Item
+            Add Item
           </button>
         </mat-card-content>
       </mat-card>

--- a/frontend/src/app/list/components/list-details/list-details.component.ts
+++ b/frontend/src/app/list/components/list-details/list-details.component.ts
@@ -113,10 +113,10 @@ export class ListDetailsComponent implements OnInit {
         this.listItemService.addListItem(this.listId, result).subscribe({
           next: () => {
             this.loadData();
-            this.feedback.success('Item adicionado com sucesso');
+            this.feedback.success('Item added successfully');
           },
           error: () => {
-            this.feedback.error('Erro ao adicionar item');
+            this.feedback.error('Error adding item');
           },
         });
       }
@@ -136,10 +136,10 @@ export class ListDetailsComponent implements OnInit {
           .subscribe({
             next: () => {
               this.loadData();
-              this.feedback.success('Item atualizado com sucesso');
+              this.feedback.success('Item updated successfully');
             },
             error: () => {
-              this.feedback.error('Erro ao atualizar item');
+              this.feedback.error('Error updating item');
             },
           });
       }
@@ -149,9 +149,9 @@ export class ListDetailsComponent implements OnInit {
   removeItem(item: ListItemResponseDTO): void {
     this.confirmDialog
       .open({
-        title: 'Remover item',
-        message: `Tem certeza que deseja remover ${item.item.name} da lista?`,
-        confirmText: 'Remover',
+        title: 'Remove Item',
+        message: `Are you sure you want to remove ${item.item.name} from the list?`,
+        confirmText: 'Remove',
       })
       .subscribe((confirmed) => {
         if (!confirmed) return;
@@ -161,10 +161,10 @@ export class ListDetailsComponent implements OnInit {
           .subscribe({
             next: () => {
               this.loadData();
-              this.feedback.success('Item removido com sucesso');
+              this.feedback.success('Item removed successfully');
             },
             error: () => {
-              this.feedback.error('Erro ao remover item');
+              this.feedback.error('Error removing item');
             },
           });
       });

--- a/frontend/src/app/list/components/list-details/list-item-dialog/list-item-dialog.component.html
+++ b/frontend/src/app/list/components/list-details/list-item-dialog/list-item-dialog.component.html
@@ -1,5 +1,5 @@
 <h2 mat-dialog-title>
-  {{ data.listItem ? "Editar" : "Adicionar" }} Item na Lista
+  {{ data.listItem ? "Edit Item in List" : "Add Item to List" }}
 </h2>
 <mat-dialog-content [formGroup]="form">
   <mat-form-field appearance="outline" class="w-100">
@@ -12,18 +12,18 @@
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="w-100">
-    <mat-label>Quantidade</mat-label>
+    <mat-label>Quantity</mat-label>
     <input matInput type="number" formControlName="quantity" min="1" required />
   </mat-form-field>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()">Cancelar</button>
+  <button mat-button (click)="onCancel()">Cancel</button>
   <button
     mat-raised-button
     color="primary"
     (click)="onSave()"
     [disabled]="form.invalid"
   >
-    Salvar
+    Save
   </button>
 </mat-dialog-actions>

--- a/frontend/src/app/list/components/list-share-dialog/list-share-dialog.component.ts
+++ b/frontend/src/app/list/components/list-share-dialog/list-share-dialog.component.ts
@@ -92,7 +92,7 @@ export class ListShareDialogComponent implements OnInit {
           this.isLoading.set(false);
         },
         error: () => {
-          this.feedback.error('Erro ao carregar permissoes');
+          this.feedback.error('Error loading permissions');
           this.isLoading.set(false);
         },
       });
@@ -104,7 +104,7 @@ export class ListShareDialogComponent implements OnInit {
         this.users.set(users);
       },
       error: () => {
-        this.feedback.error('Erro ao carregar usuarios');
+        this.feedback.error('Error loading users');
       },
     });
   }
@@ -115,7 +115,7 @@ export class ListShareDialogComponent implements OnInit {
       const user = this.users().find((u) => u.email === email);
 
       if (!user || !user.id) {
-        this.feedback.error('Usuario nao encontrado com este e-mail');
+        this.feedback.error('User not found with this email');
         return;
       }
 
@@ -127,12 +127,12 @@ export class ListShareDialogComponent implements OnInit {
 
       this.listPermissionService.addListPermission(request).subscribe({
         next: () => {
-          this.feedback.success('Lista compartilhada com sucesso');
+          this.feedback.success('List shared successfully');
           this.shareForm.reset({ permission: Permission.READ });
           this.loadPermissions();
         },
         error: () => {
-          this.feedback.error('Erro ao compartilhar lista');
+          this.feedback.error('Error sharing list');
         },
       });
     }
@@ -141,9 +141,9 @@ export class ListShareDialogComponent implements OnInit {
   removePermission(permissionId: number): void {
     this.confirmDialog
       .open({
-        title: 'Remover permissao',
-        message: 'Tem certeza que deseja remover esta permissao?',
-        confirmText: 'Remover',
+        title: 'Remove Permission',
+        message: 'Are you sure you want to remove this permission?',
+        confirmText: 'Remove',
       })
       .subscribe((confirmed) => {
         if (!confirmed) return;
@@ -152,11 +152,11 @@ export class ListShareDialogComponent implements OnInit {
           .deleteListPermission(this.data.listId, permissionId)
           .subscribe({
             next: () => {
-              this.feedback.success('Permissao removida com sucesso');
+              this.feedback.success('Permission removed successfully');
               this.loadPermissions();
             },
             error: () => {
-              this.feedback.error('Erro ao remover permissao');
+              this.feedback.error('Error removing permission');
             },
           });
       });

--- a/frontend/src/app/list/components/shopping-list-dialog/shopping-list-dialog.component.html
+++ b/frontend/src/app/list/components/shopping-list-dialog/shopping-list-dialog.component.html
@@ -1,32 +1,28 @@
-<h2 mat-dialog-title>{{ isEdit() ? "Editar Lista" : "Nova Lista" }}</h2>
+<h2 mat-dialog-title>{{ isEdit() ? "Edit List" : "New List" }}</h2>
 
 <mat-dialog-content>
   <form [formGroup]="listForm">
     <mat-form-field appearance="outline" class="w-100">
-      <mat-label>Nome da Lista</mat-label>
-      <input
-        matInput
-        formControlName="name"
-        placeholder="Digite o nome da lista"
-      />
+      <mat-label>List Name</mat-label>
+      <input matInput formControlName="name" placeholder="Enter list name" />
       @if (listForm.get("name")?.hasError("required")) {
-        <mat-error>Nome é obrigatório</mat-error>
+        <mat-error>Name is required</mat-error>
       }
       @if (listForm.get("name")?.hasError("minlength")) {
-        <mat-error>Nome deve ter pelo menos 3 caracteres</mat-error>
+        <mat-error>Name must have at least 3 characters</mat-error>
       }
     </mat-form-field>
   </form>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()">Cancelar</button>
+  <button mat-button (click)="onCancel()">Cancel</button>
   <button
     mat-raised-button
     color="primary"
     (click)="onSubmit()"
     [disabled]="!listForm.valid"
   >
-    {{ isEdit() ? "Atualizar" : "Criar" }}
+    {{ isEdit() ? "Update" : "Create" }}
   </button>
 </mat-dialog-actions>

--- a/frontend/src/app/list/components/shopping-list-dialog/shopping-list-dialog.component.ts
+++ b/frontend/src/app/list/components/shopping-list-dialog/shopping-list-dialog.component.ts
@@ -77,21 +77,21 @@ export class ShoppingListDialogComponent {
           .updateShoppingList(this.data.list.idList, listData)
           .subscribe({
             next: () => {
-              this.feedback.success('Lista atualizada com sucesso');
+              this.feedback.success('List updated successfully');
               this.dialogRef.close(true);
             },
             error: () => {
-              this.feedback.error('Erro ao atualizar lista');
+              this.feedback.error('Error updating list');
             },
           });
       } else {
         this.shoppingListService.createShoppingList(listData).subscribe({
           next: () => {
-            this.feedback.success('Lista criada com sucesso');
+            this.feedback.success('List created successfully');
             this.dialogRef.close(true);
           },
           error: () => {
-            this.feedback.error('Erro ao criar lista');
+            this.feedback.error('Error creating list');
           },
         });
       }

--- a/frontend/src/app/list/components/shopping-list/shopping-list.component.html
+++ b/frontend/src/app/list/components/shopping-list/shopping-list.component.html
@@ -1,7 +1,7 @@
 <div class="lists-container">
   <mat-card>
     <mat-card-header>
-      <mat-card-title>Minhas Listas de Compras</mat-card-title>
+      <mat-card-title>My Shopping Lists</mat-card-title>
     </mat-card-header>
 
     <mat-card-content>
@@ -16,7 +16,7 @@
               <mat-card-header>
                 <mat-card-title>{{ list.listName }}</mat-card-title>
                 <mat-card-subtitle
-                  >Criada por: {{ list.owner.fullName }}</mat-card-subtitle
+                  >Created by: {{ list.owner.fullName }}</mat-card-subtitle
                 >
               </mat-card-header>
 
@@ -33,7 +33,7 @@
                   mat-icon-button
                   color="accent"
                   [routerLink]="['/lists', list.idList]"
-                  title="Visualizar"
+                  title="View"
                 >
                   <mat-icon>visibility</mat-icon>
                 </button>
@@ -41,7 +41,7 @@
                   mat-icon-button
                   color="primary"
                   (click)="openShareDialog(list)"
-                  title="Compartilhar"
+                  title="Share"
                 >
                   <mat-icon>share</mat-icon>
                 </button>
@@ -49,7 +49,7 @@
                   mat-icon-button
                   color="warn"
                   (click)="deleteList(list.idList)"
-                  title="Excluir"
+                  title="Delete"
                 >
                   <mat-icon>delete</mat-icon>
                 </button>
@@ -57,13 +57,13 @@
             </mat-card>
           } @empty {
             <div class="no-lists">
-              <p>Você ainda não tem nenhuma lista de compras</p>
+              <p>You don't have any shopping lists yet</p>
               <button
                 mat-raised-button
                 color="primary"
                 (click)="openNewListDialog()"
               >
-                Criar Primeira Lista
+                Create First List
               </button>
             </div>
           }
@@ -74,7 +74,7 @@
     <mat-card-actions>
       <button mat-raised-button color="primary" (click)="openNewListDialog()">
         <mat-icon>add</mat-icon>
-        Nova Lista
+        Create New List
       </button>
     </mat-card-actions>
   </mat-card>

--- a/frontend/src/app/list/components/shopping-list/shopping-list.component.ts
+++ b/frontend/src/app/list/components/shopping-list/shopping-list.component.ts
@@ -55,7 +55,7 @@ export class ShoppingListComponent implements OnInit {
         this.isLoading.set(false);
       },
       error: () => {
-        this.feedback.error('Erro ao carregar listas');
+        this.feedback.error('Error loading lists');
         this.isLoading.set(false);
       },
     });
@@ -90,9 +90,9 @@ export class ShoppingListComponent implements OnInit {
   deleteList(id: number): void {
     this.confirmDialog
       .open({
-        title: 'Excluir lista',
-        message: 'Tem certeza que deseja excluir esta lista?',
-        confirmText: 'Excluir',
+        title: 'Delete List',
+        message: 'Are you sure you want to delete this list?',
+        confirmText: 'Delete',
       })
       .subscribe((confirmed) => {
         if (!confirmed) return;
@@ -100,10 +100,10 @@ export class ShoppingListComponent implements OnInit {
         this.shoppingListService.deleteShoppingList(id).subscribe({
           next: () => {
             this.loadLists();
-            this.feedback.success('Lista excluída com sucesso');
+            this.feedback.success('List deleted successfully');
           },
           error: () => {
-            this.feedback.error('Erro ao excluir lista');
+            this.feedback.error('Error deleting list');
           },
         });
       });

--- a/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.html
+++ b/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.html
@@ -1,33 +1,33 @@
-<h2 mat-dialog-title>{{ data.unit ? "Editar" : "Nova" }} Unidade</h2>
+<h2 mat-dialog-title>{{ data.unit ? "Edit" : "New" }} Unit</h2>
 <form [formGroup]="unitForm" (ngSubmit)="onSave()">
   <mat-dialog-content>
     <mat-form-field appearance="outline" class="w-100">
-      <mat-label>Nome</mat-label>
+      <mat-label>Name</mat-label>
       <input matInput formControlName="name" required />
       <mat-error *ngIf="unitForm.get('name')?.hasError('required')">
-        O nome é obrigatório
+        Name is required
       </mat-error>
       <mat-error *ngIf="unitForm.get('name')?.hasError('duplicateName')">
-        Esta unidade já existe
+        This unit already exists
       </mat-error>
     </mat-form-field>
     <mat-form-field appearance="outline" class="w-100">
-      <mat-label>Símbolo</mat-label>
+      <mat-label>Symbol</mat-label>
       <input matInput formControlName="symbol" required />
       <mat-error *ngIf="unitForm.get('symbol')?.hasError('required')">
-        O símbolo é obrigatório
+        Symbol is required
       </mat-error>
     </mat-form-field>
   </mat-dialog-content>
   <mat-dialog-actions align="end">
-    <button type="button" mat-button (click)="onCancel()">Cancelar</button>
+    <button type="button" mat-button (click)="onCancel()">Cancel</button>
     <button
       type="submit"
       mat-raised-button
       color="primary"
       [disabled]="unitForm.invalid"
     >
-      Salvar
+      Save
     </button>
   </mat-dialog-actions>
 </form>

--- a/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
+++ b/frontend/src/app/list/components/units-management/unit-dialog/unit-dialog.component.ts
@@ -90,7 +90,7 @@ export class UnitDialogComponent implements OnInit {
         this.updateNameValidator();
       },
       error: () => {
-        this.feedback.error('Erro ao carregar unidades para validação');
+        this.feedback.error('Error loading units for validation');
       },
     });
   }

--- a/frontend/src/app/list/components/units-management/units-management.component.html
+++ b/frontend/src/app/list/components/units-management/units-management.component.html
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="page-header">
-    <h1>Gerenciar Unidades</h1>
+    <h1>Manage Units</h1>
   </div>
 
   @if (loading()) {
@@ -12,9 +12,9 @@
       <mat-card appearance="outlined" class="error-card">
         <mat-card-content>
           <mat-icon color="warn">error</mat-icon>
-          <p>Erro ao carregar unidades. Tente novamente mais tarde.</p>
+          <p>Error loading units. Please try again later.</p>
           <button mat-stroked-button color="primary" (click)="loadUnits()">
-            Tentar Novamente
+            Try Again
           </button>
         </mat-card-content>
       </mat-card>
@@ -22,7 +22,7 @@
   } @else {
     <div class="add-unit-container mb-3">
       <button mat-raised-button color="primary" (click)="openNewUnitDialog()">
-        <mat-icon>add</mat-icon> Nova Unidade
+        <mat-icon>add</mat-icon> New Unit
       </button>
     </div>
 
@@ -32,25 +32,25 @@
           <table mat-table [dataSource]="units()" class="unit-table">
             <!-- Name Column -->
             <ng-container matColumnDef="name">
-              <th mat-header-cell *matHeaderCellDef>Nome</th>
+              <th mat-header-cell *matHeaderCellDef>Name</th>
               <td mat-cell *matCellDef="let element">{{ element.name }}</td>
             </ng-container>
 
             <!-- Symbol Column -->
             <ng-container matColumnDef="symbol">
-              <th mat-header-cell *matHeaderCellDef>Símbolo</th>
+              <th mat-header-cell *matHeaderCellDef>Symbol</th>
               <td mat-cell *matCellDef="let element">{{ element.symbol }}</td>
             </ng-container>
 
             <!-- Actions Column -->
             <ng-container matColumnDef="actions">
-              <th mat-header-cell *matHeaderCellDef>Ações</th>
+              <th mat-header-cell *matHeaderCellDef>Actions</th>
               <td mat-cell *matCellDef="let element">
                 <button
                   mat-icon-button
                   color="primary"
                   (click)="editUnit(element)"
-                  aria-label="Editar unidade"
+                  aria-label="Edit Unit"
                 >
                   <mat-icon>edit</mat-icon>
                 </button>
@@ -58,7 +58,7 @@
                   mat-icon-button
                   color="warn"
                   (click)="deleteUnit(element)"
-                  aria-label="Excluir unidade"
+                  aria-label="Delete Unit"
                 >
                   <mat-icon>delete</mat-icon>
                 </button>
@@ -73,13 +73,13 @@
     } @else {
       <mat-card appearance="outlined" class="empty-state">
         <mat-card-content>
-          <p>Nenhuma unidade cadastrada.</p>
+          <p>No units registered.</p>
           <button
             mat-raised-button
             color="primary"
             (click)="openNewUnitDialog()"
           >
-            Cadastrar Primeira Unidade
+            Add First Unit
           </button>
         </mat-card-content>
       </mat-card>

--- a/frontend/src/app/list/components/units-management/units-management.component.ts
+++ b/frontend/src/app/list/components/units-management/units-management.component.ts
@@ -61,9 +61,7 @@ export class UnitsManagementComponent implements OnInit {
         catchError(() => {
           this.error.set(true);
           this.units.set([]);
-          this.feedback.error(
-            'Erro ao carregar unidades. Tente novamente mais tarde.',
-          );
+          this.feedback.error('Error loading units. Please try again later.');
           return of([]);
         }),
         finalize(() => {
@@ -84,10 +82,10 @@ export class UnitsManagementComponent implements OnInit {
         this.unitService.updateUnit(result).subscribe({
           next: () => {
             this.loadUnits();
-            this.feedback.success('Unidade atualizada com sucesso');
+            this.feedback.success('Unit updated successfully');
           },
           error: () => {
-            this.feedback.error('Erro ao atualizar unidade');
+            this.feedback.error('Error updating unit');
           },
         });
       }
@@ -97,9 +95,9 @@ export class UnitsManagementComponent implements OnInit {
   deleteUnit(unit: Unit): void {
     this.confirmDialog
       .open({
-        title: 'Excluir unidade',
-        message: `Tem certeza que deseja excluir a unidade "${unit.name}"?`,
-        confirmText: 'Excluir',
+        title: 'Delete Unit',
+        message: `Are you sure you want to delete the unit "${unit.name}"?`,
+        confirmText: 'Delete',
       })
       .subscribe((confirmed) => {
         if (!confirmed) return;
@@ -107,10 +105,10 @@ export class UnitsManagementComponent implements OnInit {
         this.unitService.deleteUnit(unit.id!).subscribe({
           next: () => {
             this.loadUnits();
-            this.feedback.success('Unidade excluida com sucesso');
+            this.feedback.success('Unit deleted successfully');
           },
           error: () => {
-            this.feedback.error('Erro ao excluir unidade');
+            this.feedback.error('Error deleting unit');
           },
         });
       });
@@ -127,10 +125,10 @@ export class UnitsManagementComponent implements OnInit {
         this.unitService.addUnit(result).subscribe({
           next: () => {
             this.loadUnits();
-            this.feedback.success('Unidade adicionada com sucesso');
+            this.feedback.success('Unit added successfully');
           },
           error: () => {
-            this.feedback.error('Erro ao adicionar unidade');
+            this.feedback.error('Error adding unit');
           },
         });
       }

--- a/frontend/src/app/shared/components/category/category.component.html
+++ b/frontend/src/app/shared/components/category/category.component.html
@@ -2,7 +2,7 @@
   <mat-card class="form-card">
     <mat-card-header>
       <mat-card-title>{{
-        editingCategoryId() ? "Edit Category" : "New Category"
+        editingCategoryId() ? "Update" : "Create"
       }}</mat-card-title>
     </mat-card-header>
     <mat-card-content>

--- a/frontend/src/app/shared/components/category/category.component.ts
+++ b/frontend/src/app/shared/components/category/category.component.ts
@@ -70,7 +70,7 @@ export class CategoryComponent implements OnInit {
         this.isLoading.set(false);
       },
       error: () => {
-        this.feedback.error('Erro ao carregar categorias');
+        this.feedback.error('Error loading categories');
         this.isLoading.set(false);
       },
     });
@@ -95,14 +95,14 @@ export class CategoryComponent implements OnInit {
       next: () => {
         this.feedback.success(
           this.editingCategoryId() !== null
-            ? 'Categoria atualizada com sucesso'
-            : 'Categoria criada com sucesso',
+            ? 'Category updated successfully'
+            : 'Category created successfully',
         );
         this.resetForm();
         this.loadCategories();
       },
       error: () => {
-        this.feedback.error('Erro ao salvar categoria');
+        this.feedback.error('Error saving category');
       },
     });
   }
@@ -117,20 +117,20 @@ export class CategoryComponent implements OnInit {
   deleteCategory(id: number): void {
     this.confirmDialog
       .open({
-        title: 'Excluir categoria',
-        message: 'Tem certeza que deseja excluir esta categoria?',
-        confirmText: 'Excluir',
+        title: 'Delete Category',
+        message: 'Are you sure you want to delete this category?',
+        confirmText: 'Delete',
       })
       .subscribe((confirmed) => {
         if (!confirmed) return;
 
         this.categoryService.deleteCategory(id).subscribe({
           next: () => {
-            this.feedback.success('Categoria excluída com sucesso');
+            this.feedback.success('Category deleted successfully');
             this.loadCategories();
           },
           error: () => {
-            this.feedback.error('Erro ao excluir categoria');
+            this.feedback.error('Error deleting category');
           },
         });
       });

--- a/frontend/src/app/shared/components/item/item.component.ts
+++ b/frontend/src/app/shared/components/item/item.component.ts
@@ -88,7 +88,7 @@ export class ItemComponent implements OnInit {
         this.isLoading.set(false);
       },
       error: () => {
-        this.feedback.error('Erro ao carregar dados');
+        this.feedback.error('Error loading data');
         this.isLoading.set(false);
       },
     });
@@ -110,14 +110,14 @@ export class ItemComponent implements OnInit {
       next: () => {
         this.feedback.success(
           this.editingItemId()
-            ? 'Item atualizado com sucesso'
-            : 'Item criado com sucesso',
+            ? 'Item updated successfully'
+            : 'Item created successfully',
         );
         this.resetForm();
         this.loadInitialData();
       },
       error: () => {
-        this.feedback.error('Erro ao salvar item');
+        this.feedback.error('Error saving item');
       },
     });
   }
@@ -134,20 +134,20 @@ export class ItemComponent implements OnInit {
   deleteItem(id: number): void {
     this.confirmDialog
       .open({
-        title: 'Excluir item',
-        message: 'Tem certeza que deseja excluir este item?',
-        confirmText: 'Excluir',
+        title: 'Delete Item',
+        message: 'Are you sure you want to delete this item?',
+        confirmText: 'Delete',
       })
       .subscribe((confirmed) => {
         if (!confirmed) return;
 
         this.itemService.deleteItem(id).subscribe({
           next: () => {
-            this.feedback.success('Item excluído com sucesso');
+            this.feedback.success('Item deleted successfully');
             this.loadInitialData();
           },
           error: () => {
-            this.feedback.error('Erro ao excluir item');
+            this.feedback.error('Error deleting item');
           },
         });
       });

--- a/frontend/src/app/shared/components/list-item/list-item.component.ts
+++ b/frontend/src/app/shared/components/list-item/list-item.component.ts
@@ -88,7 +88,7 @@ export class ListItemComponent implements OnInit {
         this.isLoading.set(false);
       },
       error: () => {
-        this.feedback.error('Erro ao carregar dados');
+        this.feedback.error('Error loading data');
         this.isLoading.set(false);
       },
     });
@@ -119,14 +119,14 @@ export class ListItemComponent implements OnInit {
       next: () => {
         this.feedback.success(
           this.editingListItemId()
-            ? 'Item atualizado com sucesso'
-            : 'Item adicionado com sucesso',
+            ? 'Item updated successfully'
+            : 'Item created successfully',
         );
         this.resetForm();
         this.loadInitialData();
       },
       error: () => {
-        this.feedback.error('Erro ao salvar item da lista');
+        this.feedback.error('Error saving list item');
       },
     });
   }
@@ -144,20 +144,20 @@ export class ListItemComponent implements OnInit {
   deleteListItem(id: number): void {
     this.confirmDialog
       .open({
-        title: 'Remover item',
-        message: 'Tem certeza que deseja remover este item da lista?',
-        confirmText: 'Remover',
+        title: 'Delete Item',
+        message: 'Are you sure you want to delete this item from the list?',
+        confirmText: 'Delete',
       })
       .subscribe((confirmed) => {
         if (!confirmed) return;
 
         this.listItemService.deleteListItem(this.listId, id).subscribe({
           next: () => {
-            this.feedback.success('Item removido com sucesso');
+            this.feedback.success('Item deleted successfully');
             this.loadInitialData();
           },
           error: () => {
-            this.feedback.error('Erro ao remover item');
+            this.feedback.error('Error deleting item');
           },
         });
       });
@@ -178,7 +178,7 @@ export class ListItemComponent implements OnInit {
           this.loadInitialData();
         },
         error: () => {
-          this.feedback.error('Erro ao atualizar status do item');
+          this.feedback.error('Error updating item status');
         },
       });
   }

--- a/frontend/src/app/shared/components/unit/unit.component.ts
+++ b/frontend/src/app/shared/components/unit/unit.component.ts
@@ -1,8 +1,8 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  inject,
   OnInit,
+  inject,
   signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -67,7 +67,7 @@ export class UnitComponent implements OnInit {
         this.isLoading.set(false);
       },
       error: () => {
-        this.feedback.error('Erro ao carregar unidades');
+        this.feedback.error('Error loading units');
         this.isLoading.set(false);
       },
     });
@@ -97,14 +97,14 @@ export class UnitComponent implements OnInit {
       next: () => {
         this.feedback.success(
           editingId !== null
-            ? 'Unidade atualizada com sucesso'
-            : 'Unidade criada com sucesso',
+            ? 'Unit updated successfully'
+            : 'Unit created successfully',
         );
         this.resetForm();
         this.loadUnits();
       },
       error: () => {
-        this.feedback.error('Erro ao salvar unidade');
+        this.feedback.error('Error saving unit');
       },
     });
   }
@@ -120,20 +120,20 @@ export class UnitComponent implements OnInit {
   deleteUnit(id: number): void {
     this.confirmDialog
       .open({
-        title: 'Excluir unidade',
-        message: 'Tem certeza que deseja excluir esta unidade?',
-        confirmText: 'Excluir',
+        title: 'Delete Unit',
+        message: 'Are you sure you want to delete this unit?',
+        confirmText: 'Delete',
       })
-      .subscribe((confirmed: boolean) => {
+      .subscribe((confirmed) => {
         if (!confirmed) return;
 
         this.unitService.deleteUnit(id).subscribe({
           next: () => {
-            this.feedback.success('Unidade excluída com sucesso');
+            this.feedback.success('Unit deleted successfully');
             this.loadUnits();
           },
           error: () => {
-            this.feedback.error('Erro ao excluir unidade');
+            this.feedback.error('Error deleting unit');
           },
         });
       });

--- a/frontend/src/app/shared/services/feedback.service.ts
+++ b/frontend/src/app/shared/services/feedback.service.ts
@@ -8,14 +8,14 @@ export class FeedbackService {
   private readonly snackBar = inject(MatSnackBar);
 
   success(message: string): void {
-    this.snackBar.open(message, 'Fechar', {
+    this.snackBar.open(message, 'Close', {
       duration: 3000,
       panelClass: ['success-snackbar'],
     });
   }
 
   error(message: string): void {
-    this.snackBar.open(message, 'Fechar', {
+    this.snackBar.open(message, 'Close', {
       duration: 3000,
       panelClass: ['error-snackbar'],
     });


### PR DESCRIPTION
Translate all remaining PT-BR UI text and logs to English in frontend.
Closes: #106 

Changes:
- Updated login and signup pages
- Translated dialogs and buttons
- Standardized UI terminology across components

No logic changes were made, only text translations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Complete translation of the user interface from Portuguese to English, including form labels, input placeholders, button text, error and validation messages, dialog titles, success and error notifications, confirmation prompts, and help text across all app features (authentication, lists, items, categories, units, and sharing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->