### PR TITLE
Implement JPA auditing and soft delete supportFinal shopmate pr

### DIFF
--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/ShoppMateApplication.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/ShoppMateApplication.java
@@ -2,9 +2,11 @@ package com.omatheusmesmo.shoppmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
+@EnableJpaAuditing
 @RestController
 public class ShoppMateApplication {
 

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/category/entity/Category.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/category/entity/Category.java
@@ -5,9 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "categories")
+@SQLDelete(sql = "UPDATE categories SET deleted = true WHERE id=?")
+@Where(clause = "deleted = false")
 @Getter
 @Setter
 public class Category extends DomainEntity {

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/item/entity/Item.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/item/entity/Item.java
@@ -12,8 +12,12 @@ import lombok.Setter;
 import com.omatheusmesmo.shoppmate.category.entity.Category;
 import com.omatheusmesmo.shoppmate.shared.domain.DomainEntity;
 import com.omatheusmesmo.shoppmate.unit.entity.Unit;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @NoArgsConstructor
+@SQLDelete(sql = "UPDATE items SET deleted = true WHERE id=?")
+@Where(clause = "deleted = false")
 @Getter
 @Setter
 @Entity

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/list/entity/ListItem.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/list/entity/ListItem.java
@@ -13,8 +13,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
+@SQLDelete(sql = "UPDATE list_items SET deleted = true WHERE id=?")
+@Where(clause = "deleted = false")
 @Table(name = "list_items")
 @Getter
 @Setter

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/list/entity/ListPermission.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/list/entity/ListPermission.java
@@ -13,9 +13,13 @@ import lombok.Setter;
 
 import com.omatheusmesmo.shoppmate.shared.domain.BaseAuditableEntity;
 import com.omatheusmesmo.shoppmate.user.entity.User;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "list_user_permissions")
+@SQLDelete(sql = "UPDATE list_user_permissions SET deleted = true WHERE id=?")
+@Where(clause = "deleted = false")
 @Getter
 @Setter
 public class ListPermission extends BaseAuditableEntity {

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/list/entity/ShoppingList.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/list/entity/ShoppingList.java
@@ -16,8 +16,12 @@ import lombok.Setter;
 
 import com.omatheusmesmo.shoppmate.shared.domain.DomainEntity;
 import com.omatheusmesmo.shoppmate.user.entity.User;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
+@SQLDelete(sql = "UPDATE lists SET deleted = true WHERE id=?")
+@Where(clause = "deleted = false")
 @Table(name = "lists")
 @Getter
 @Setter

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/shared/domain/BaseAuditableEntity.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/shared/domain/BaseAuditableEntity.java
@@ -9,8 +9,13 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import jakarta.persistence.EntityListeners;
 
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 public abstract class BaseAuditableEntity implements AuditableEntity {
@@ -21,9 +26,11 @@ public abstract class BaseAuditableEntity implements AuditableEntity {
     @Column(name = "id")
     private Long id;
 
+    @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/shared/domain/BaseAuditableEntity.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/shared/domain/BaseAuditableEntity.java
@@ -13,6 +13,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.EntityListeners;
+import lombok.AccessLevel;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -27,10 +28,12 @@ public abstract class BaseAuditableEntity implements AuditableEntity {
     private Long id;
 
     @CreatedDate
-    @Column(name = "created_at")
+    @Setter(AccessLevel.NONE)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Setter(AccessLevel.NONE)
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/shared/domain/DomainEntity.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/shared/domain/DomainEntity.java
@@ -8,10 +8,15 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import jakarta.persistence.EntityListeners;
 
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 public abstract class DomainEntity implements AuditableEntity {
@@ -24,9 +29,11 @@ public abstract class DomainEntity implements AuditableEntity {
 
     private String name;
 
+    @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/shared/domain/DomainEntity.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/shared/domain/DomainEntity.java
@@ -14,6 +14,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.EntityListeners;
 
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -30,10 +31,12 @@ public abstract class DomainEntity implements AuditableEntity {
     private String name;
 
     @CreatedDate
-    @Column(name = "created_at")
+    @Setter(AccessLevel.NONE)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Setter(AccessLevel.NONE)
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/unit/entity/Unit.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/unit/entity/Unit.java
@@ -6,8 +6,12 @@ import lombok.Getter;
 import lombok.Setter;
 
 import com.omatheusmesmo.shoppmate.shared.domain.DomainEntity;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
+@SQLDelete(sql = "UPDATE units SET deleted = true WHERE id=?")
+@Where(clause = "deleted = false")
 @Table(name = "units")
 @Getter
 @Setter

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/user/entity/User.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/user/entity/User.java
@@ -18,12 +18,16 @@ import lombok.Setter;
 
 import com.omatheusmesmo.shoppmate.shared.domain.BaseAuditableEntity;
 import com.omatheusmesmo.shoppmate.user.dtos.RegisterUserDTO;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
 @Entity
+@SQLDelete(sql = "UPDATE users SET deleted = true WHERE id=?")
+@Where(clause = "deleted = false")
 @Table(name = "users")
 public class User extends BaseAuditableEntity implements UserDetails {
 


### PR DESCRIPTION
## Changes made
Closes: #23 

* Enabled Spring Data JPA auditing
* Added `@EnableJpaAuditing` in `ShoppMateApplication`
* Added auditing annotations to `BaseAuditableEntity`
* Added auditing support to `DomainEntity`
* Implemented soft delete using `@SQLDelete` and `@Where`
* Applied soft delete to:

  * Category
  * Item
  * ListItem
  * Unit
  * User
  * ShoppingList
  * ListPermission

This improves entity lifecycle tracking and prevents permanent deletion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic auditing now tracks when entities are created and last modified across the application.
  * Soft-delete functionality has been implemented for shopping lists, items, categories, units, and user accounts—records are marked as deleted rather than permanently removed, allowing for data recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omatheusmesmo/ShoppMate/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->