### PR TITLE
test(auth, shopping): add unit tests for services

### DIFF
--- a/frontend/src/app/shared/services/auth.service.spec.ts
+++ b/frontend/src/app/shared/services/auth.service.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { AuthService } from './auth.service';
+import { MockRouter } from '../../shared/mocks/mock-services';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+  let routerMock: MockRouter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AuthService, { provide: Router, useClass: MockRouter }],
+    });
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+    routerMock = TestBed.inject(Router) as unknown as MockRouter;
+    localStorage.clear();
+  });
+
+  it('should login and save token', () => {
+    const mockToken = 'fake-jwt-token';
+    service.login({ email: 'test@test.com', password: '123' }).subscribe((token) => {
+      expect(token).toBe(mockToken);
+      expect(localStorage.getItem('auth_token')).toBe(mockToken);
+    });
+
+    const req = httpMock.expectOne('/api/auth/login');
+    expect(req.request.method).toBe('POST');
+    req.flush(mockToken);
+  });
+
+  it('should handle 403 forbidden error', () => {
+    service.login({ email: 'wrong@test.com', password: '123' }).subscribe({
+      error: (err) => expect(err.message).toBe('Credenciais inválidas'),
+    });
+
+    const req = httpMock.expectOne('/api/auth/login');
+    req.flush('Forbidden', { status: 403, statusText: 'Forbidden' });
+  });
+
+  it('should logout, clear token, and navigate to /login', () => {
+    localStorage.setItem('auth_token', 'active-token');
+    service.logout();
+
+    expect(localStorage.getItem('auth_token')).toBeNull();
+    expect(routerMock.navigate).toHaveBeenCalledWith(['/login']);
+  });
+
+  afterEach(() => httpMock.verify());
+});

--- a/frontend/src/app/shared/services/shopping-list.service.spec.ts
+++ b/frontend/src/app/shared/services/shopping-list.service.spec.ts
@@ -1,0 +1,62 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ShoppingListService } from './shopping-list.service';
+import { environment } from '../../../environments/environment';
+import { ShoppingListResponseDTO } from '../interfaces/shopping-list.interface';
+import { ListItemResponseDTO, ListItemRequestDTO } from '../interfaces/list-item.interface';
+
+describe('ShoppingListService', () => {
+  let service: ShoppingListService;
+  let httpMock: HttpTestingController;
+  const apiUrl = `${environment.apiUrl}/lists`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ShoppingListService],
+    });
+    service = TestBed.inject(ShoppingListService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  it('should fetch all shopping lists', () => {
+    const mockLists: ShoppingListResponseDTO[] = [
+      {
+        idList: 1,
+        listName: 'Groceries',
+        owner: { id: 1, fullName: 'User', email: 'test@test.com' },
+        totalValue: 10.0,
+      },
+    ];
+
+    service.getAllShoppingLists().subscribe((lists) => {
+      expect(lists).toEqual(mockLists);
+    });
+
+    const req = httpMock.expectOne(apiUrl);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockLists);
+  });
+
+  it('should add a list item', () => {
+    const mockItemRequest: ListItemRequestDTO = { listId: 1, itemId: 5, quantity: 2 };
+
+    const mockItemResponse = {
+      idListItem: 10,
+      quantity: 2,
+      purchased: false,
+      unitPrice: 5.0,
+      totalPrice: 10.0,
+    } as ListItemResponseDTO;
+
+    service.addListItem(mockItemRequest).subscribe((res) => {
+      expect(res.idListItem).toEqual(10);
+    });
+
+    const req = httpMock.expectOne(`${apiUrl}/1/items`);
+    expect(req.request.method).toBe('POST');
+    req.flush(mockItemResponse);
+  });
+
+  afterEach(() => httpMock.verify());
+});


### PR DESCRIPTION
Closes #34 

Added unit tests for AuthService and ShoppingListService to achieve 80% code coverage. Verified that all tests pass and follow project standards by running npm run test:ci, npm run lint, and npm run prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/extended unit tests for authentication, covering successful login, invalid-login error handling, token persistence in local storage, and logout navigation.
  * Added unit tests for the shopping list service, covering fetching shopping lists and adding list items, including expected API calls and response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->