### PR TITLE
Implement multi-stage Dockerfile setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 gha-creds-*.json
 postgres-data/
 **/postgres-data/
+.env
 
 # Eclipse IDE
 .settings/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,8 @@
 # Stage 1: Build environment
-FROM maven:3.9.6-eclipse-temurin-17-alpine AS build
+FROM maven:3.9.6-eclipse-temurin-17@sha256:29a1658b1f3078e07c2b17f7b519b45eb47f65d9628e887eac45a8c5c8f939d4 AS build
 WORKDIR /app
 
-# Copy pom.xml and download dependencies to leverage Docker cache
+# Copy pom.xml first and download dependencies to leverage Docker layer caching
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 
@@ -11,33 +11,20 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 
 # Stage 2: Runtime environment
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre@sha256:d226a3132511d057267330beeca73804275899aacdea331b7bd8313bb1506a7a
 WORKDIR /app
 
-# Create a non-root user for better security
-RUN addgroup -S spring && adduser -S spring -G spring
+# Create a non-root user for better runtime security
+RUN groupadd --system spring && useradd --system --gid spring spring
 
-# Create the directory first
-RUN mkdir -p /app/certs
+# Copy only runtime artifacts into the final image
+COPY --from=build --chown=spring:spring /app/target/*.jar app.jar
 
-# Copy the keys during the build (if they exist)
-COPY certs/ /app/certs/
-
-# Ensure the 'spring' user owns them
-RUN chown -R spring:spring /app/certs
-
-# Switch to spring user
 USER spring:spring
 
-# Copy the built artifact from the build stage
-# We use a wildcard to capture the jar, but ensure only one is copied if possible
-COPY --from=build /app/target/*.jar app.jar
-
-# Runtime configuration
 ENV JAVA_OPTS="-Xms256m -Xmx512m" \
     SERVER_PORT=8080
 
 EXPOSE 8080
 
-# Execute the application
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,14 +1,39 @@
-version: "3.8"
-
 services:
   postgres:
-    image: postgres:18
-    container_name: postgres
-    ports:
-      - "5432:5432"
+    image: postgres:18-alpine
+    container_name: shoppmate-db
     environment:
-      - POSTGRES_USER=${POSTGRES_USER:-user}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
-      - POSTGRES_DB=${POSTGRES_DB:-SHOPPMATE}
+      - POSTGRES_USER=${POSTGRES_USER:?POSTGRES_USER is required}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      - POSTGRES_DB=${POSTGRES_DB:?POSTGRES_DB is required}
     volumes:
-      - ./postgres-data:/var/lib/postgresql
+      - postgres-data:/var/lib/postgresql
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:?POSTGRES_USER is required} -d ${POSTGRES_DB:?POSTGRES_DB is required}",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: shoppmate-api
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./certs:/certs:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/${POSTGRES_DB:?POSTGRES_DB is required}
+      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER:?POSTGRES_USER is required}
+      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      - JWT_TOKEN_EXPIRATION=${JWT_TOKEN_EXPIRATION:?JWT_TOKEN_EXPIRATION is required}
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary

- Updated the backend Dockerfile to keep the application build and runtime environments separate.
- Replaced Alpine-based Java/Maven images with Java 17 Temurin images that work more reliably across local development and CI platforms.
- Kept Maven, source code, and build tooling out of the final runtime image.
- Updated the backend Docker Compose setup to run both Postgres and the backend service.
- Added a Postgres healthcheck so the backend waits for the database to be ready before starting.
- Added `.env` to `.gitignore` to prevent local environment files from being committed.

## Validation

- Ran `docker compose build backend`
- Ran `docker compose up backend`
- Confirmed the backend image built successfully.
- Confirmed Postgres started successfully.
- Confirmed the ShoppMate backend started successfully on port `8080`.

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker configuration to improve build and runtime compatibility.
  * Refined PostgreSQL container setup (new image, required env vars, health checks, and persistent named storage).
  * Added a dedicated backend container to the compose setup with proper service ordering and port mapping.
  * Tightened container networking/configuration by removing direct PostgreSQL port exposure.
  * Updated ignore rules to keep environment files out of source control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->