### PR TITLE
fix: implement BOLA protection for lists, items, and categories

### DIFF
--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/category/controller/CategoryController.java
@@ -68,9 +68,11 @@ public class CategoryController {
     @PutMapping("/{id}")
     public ResponseEntity<CategoryResponseDTO> updateCategory(@PathVariable Long id,
             @RequestBody @Valid CategoryRequestDTO categoryDTO, @AuthenticationPrincipal User user) {
-        categoryService.editCategory(id, categoryDTO, user);
-        Category updatedCategory = categoryService.findCategoryById(id);
+
+        Category updatedCategory = categoryService.editCategory(id, categoryDTO, user);
+
         CategoryResponseDTO responseDTO = categoryMapper.toResponseDTO(updatedCategory);
+
         return ResponseEntity.ok(responseDTO);
     }
 }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/category/repository/CategoryRepository.java
@@ -16,6 +16,28 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByIdAndDeletedFalse(Long id);
 
-    @Query("SELECT c FROM Category c LEFT JOIN c.owner o WHERE c.deleted = false AND (c.isSystemStandard = true OR o.id = :userId)")
+    @Query("""
+            SELECT c
+            FROM Category c
+            LEFT JOIN c.owner o
+            WHERE c.id = :categoryId
+              AND c.deleted = false
+              AND (
+                  c.isSystemStandard = true
+                  OR o.id = :userId
+              )
+            """)
+    Optional<Category> findAccessibleByIdAndUserId(@Param("categoryId") Long categoryId, @Param("userId") Long userId);
+
+    @Query("""
+            SELECT c
+            FROM Category c
+            LEFT JOIN c.owner o
+            WHERE c.deleted = false
+              AND (
+                  c.isSystemStandard = true
+                  OR o.id = :userId
+              )
+            """)
     List<Category> findAllAccessibleByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/category/service/CategoryService.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/category/service/CategoryService.java
@@ -32,7 +32,13 @@ public class CategoryService {
 
     public Category findCategoryById(Long id) {
         return categoryRepository.findByIdAndDeletedFalse(id)
-                .orElseThrow(() -> new NoSuchElementException("Item not found with id: " + id));
+                .orElseThrow(() -> new NoSuchElementException("Category not found with id: " + id));
+    }
+
+    public Category findAccessibleCategoryById(Long id, User currentUser) {
+
+        return categoryRepository.findAccessibleByIdAndUserId(id, currentUser.getId())
+                .orElseThrow(() -> new NoSuchElementException("Category not found with id: " + id));
     }
 
     public Optional<Category> findCategoryByName(String name) {
@@ -40,29 +46,39 @@ public class CategoryService {
     }
 
     public void removeCategory(Long id, User currentUser) {
+
         Category category = findCategoryById(id);
         verifyOwnershipOrSystem(category, currentUser);
+
         auditService.softDelete(category);
         auditService.setAuditData(category, false);
         categoryRepository.save(category);
     }
 
-    public void editCategory(Long id, CategoryRequestDTO requestDTO, User currentUser) {
+    public Category editCategory(Long id, CategoryRequestDTO requestDTO, User currentUser) {
+
         Category existingCategory = findCategoryById(id);
         verifyOwnershipOrSystem(existingCategory, currentUser);
+
         existingCategory.setName(requestDTO.name());
         isCategoryValid(existingCategory);
+
         auditService.setAuditData(existingCategory, false);
         categoryRepository.save(existingCategory);
+
+        return existingCategory;
     }
 
     public void verifyOwnershipOrSystem(Category category, User currentUser) {
+
         if (category.isSystemStandard()) {
             throw new ResourceOwnershipException("System standard categories cannot be modified or deleted!");
         }
+
         if (category.getOwner() == null) {
             throw new ResourceOwnershipException("Non-system categories must have an owner; operation not permitted");
         }
+
         if (!category.getOwner().getId().equals(currentUser.getId())) {
             throw new ResourceOwnershipException("You can only modify or delete categories you own!");
         }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/item/controller/ItemController.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/item/controller/ItemController.java
@@ -8,7 +8,6 @@ import com.omatheusmesmo.shoppmate.item.service.ItemService;
 import com.omatheusmesmo.shoppmate.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -65,9 +63,10 @@ public class ItemController {
 
     @Operation(summary = "Delete an item by id")
     @DeleteMapping("/{id}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteItem(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteItem(@PathVariable Long id) {
         itemService.removeItem(id);
+
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "Update an item")

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/item/controller/ItemController.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/item/controller/ItemController.java
@@ -5,10 +5,12 @@ import com.omatheusmesmo.shoppmate.item.dto.ItemResponseDTO;
 import com.omatheusmesmo.shoppmate.item.entity.Item;
 import com.omatheusmesmo.shoppmate.item.mapper.ItemMapper;
 import com.omatheusmesmo.shoppmate.item.service.ItemService;
+import com.omatheusmesmo.shoppmate.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,16 +42,19 @@ public class ItemController {
     @GetMapping
     public ResponseEntity<List<ItemResponseDTO>> getAllItems() {
         List<Item> items = itemService.findAll();
+
         List<ItemResponseDTO> responseDTOs = items.stream().map(itemMapper::toResponseDTO).toList();
+
         return ResponseEntity.ok(responseDTOs);
     }
 
     @Operation(summary = "Add a new item")
     @PostMapping
-    public ResponseEntity<ItemResponseDTO> addItem(@Valid @RequestBody ItemRequestDTO itemDTO) {
+    public ResponseEntity<ItemResponseDTO> addItem(@Valid @RequestBody ItemRequestDTO itemDTO,
+            @AuthenticationPrincipal User user) {
 
-        Item item = itemMapper.toEntity(itemDTO);
-        Item savedItem = itemService.addItem(item);
+        Item savedItem = itemService.addItem(itemDTO, user);
+
         ItemResponseDTO responseDTO = itemMapper.toResponseDTO(savedItem);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(savedItem.getId())
@@ -58,22 +63,20 @@ public class ItemController {
         return ResponseEntity.created(location).body(responseDTO);
     }
 
-    @Operation(summary = "Delete a item by id")
+    @Operation(summary = "Delete an item by id")
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteItem(@PathVariable Long id) {
         itemService.removeItem(id);
     }
 
-    @Operation(summary = "Update a item")
+    @Operation(summary = "Update an item")
     @PutMapping("/{id}")
-    public ResponseEntity<ItemResponseDTO> updateItem(@PathVariable Long id,
-            @Valid @RequestBody ItemRequestDTO itemDTO) {
+    public ResponseEntity<ItemResponseDTO> updateItem(@PathVariable Long id, @Valid @RequestBody ItemRequestDTO itemDTO,
+            @AuthenticationPrincipal User user) {
 
-        Item itemToUpdate = itemMapper.toEntity(itemDTO);
-        itemToUpdate.setId(id);
+        Item updatedItem = itemService.editItem(id, itemDTO, user);
 
-        Item updatedItem = itemService.editItem(itemToUpdate);
         ItemResponseDTO responseDTO = itemMapper.toResponseDTO(updatedItem);
 
         return ResponseEntity.ok(responseDTO);
@@ -82,8 +85,11 @@ public class ItemController {
     @Operation(summary = "Get an item by id")
     @GetMapping("/{id}")
     public ResponseEntity<ItemResponseDTO> getItemById(@PathVariable Long id) {
+
         Item item = itemService.findById(id);
+
         ItemResponseDTO responseDTO = itemMapper.toResponseDTO(item);
+
         return ResponseEntity.ok(responseDTO);
     }
 }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/item/mapper/ItemMapper.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/item/mapper/ItemMapper.java
@@ -1,52 +1,38 @@
 package com.omatheusmesmo.shoppmate.item.mapper;
 
-import com.omatheusmesmo.shoppmate.category.dto.CategoryResponseDTO;
 import com.omatheusmesmo.shoppmate.category.entity.Category;
 import com.omatheusmesmo.shoppmate.category.mapper.CategoryMapper;
-import com.omatheusmesmo.shoppmate.category.repository.CategoryRepository;
 import com.omatheusmesmo.shoppmate.item.dto.ItemRequestDTO;
 import com.omatheusmesmo.shoppmate.item.dto.ItemResponseDTO;
 import com.omatheusmesmo.shoppmate.item.entity.Item;
-import com.omatheusmesmo.shoppmate.unit.dto.UnitResponseDTO;
 import com.omatheusmesmo.shoppmate.unit.entity.Unit;
 import com.omatheusmesmo.shoppmate.unit.mapper.UnitMapper;
-import com.omatheusmesmo.shoppmate.unit.repository.UnitRepository;
 import org.springframework.stereotype.Component;
-
-import java.util.NoSuchElementException;
 
 @Component
 public class ItemMapper {
 
-    private final CategoryRepository categoryRepository;
-    private final UnitRepository unitRepository;
     private final CategoryMapper categoryMapper;
     private final UnitMapper unitMapper;
 
-    public ItemMapper(CategoryRepository categoryRepository, UnitRepository unitRepository,
-            CategoryMapper categoryMapper, UnitMapper unitMapper) {
-        this.categoryRepository = categoryRepository;
-        this.unitRepository = unitRepository;
+    public ItemMapper(CategoryMapper categoryMapper, UnitMapper unitMapper) {
         this.categoryMapper = categoryMapper;
         this.unitMapper = unitMapper;
     }
 
-    public Item toEntity(ItemRequestDTO dto) {
-        Category category = categoryRepository.findByIdAndDeletedFalse(dto.idCategory())
-                .orElseThrow(() -> new NoSuchElementException("Category not found with id: " + dto.idCategory()));
+    public Item toEntity(ItemRequestDTO dto, Category category, Unit unit) {
 
-        Unit unit = unitRepository.findByIdAndDeletedFalse(dto.idUnit())
-                .orElseThrow(() -> new NoSuchElementException("Unit not found with id: " + dto.idUnit()));
-
-        var item = new Item();
+        Item item = new Item();
         item.setName(dto.name());
         item.setCategory(category);
         item.setUnit(unit);
+
         return item;
     }
 
     public ItemResponseDTO toResponseDTO(Item entity) {
         var categoryDto = categoryMapper.toResponseDTO(entity.getCategory());
+
         var unitDto = unitMapper.toResponseDTO(entity.getUnit());
 
         return new ItemResponseDTO(entity.getId(), entity.getName(), categoryDto, unitDto);

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/item/service/ItemService.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/item/service/ItemService.java
@@ -1,10 +1,15 @@
 package com.omatheusmesmo.shoppmate.item.service;
 
+import com.omatheusmesmo.shoppmate.category.entity.Category;
 import com.omatheusmesmo.shoppmate.category.service.CategoryService;
+import com.omatheusmesmo.shoppmate.item.dto.ItemRequestDTO;
 import com.omatheusmesmo.shoppmate.item.entity.Item;
+import com.omatheusmesmo.shoppmate.item.mapper.ItemMapper;
 import com.omatheusmesmo.shoppmate.item.repository.ItemRepository;
 import com.omatheusmesmo.shoppmate.shared.service.AuditService;
+import com.omatheusmesmo.shoppmate.unit.entity.Unit;
 import com.omatheusmesmo.shoppmate.unit.service.UnitService;
+import com.omatheusmesmo.shoppmate.user.entity.User;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,18 +27,29 @@ public class ItemService {
 
     private final CategoryService categoryService;
 
+    private final ItemMapper itemMapper;
+
     public ItemService(ItemRepository itemRepository, AuditService auditService, UnitService unitService,
-            CategoryService categoryService) {
+            CategoryService categoryService, ItemMapper itemMapper) {
         this.itemRepository = itemRepository;
         this.auditService = auditService;
         this.unitService = unitService;
         this.categoryService = categoryService;
+        this.itemMapper = itemMapper;
     }
 
-    public Item addItem(Item item) {
+    public Item addItem(ItemRequestDTO itemDTO, User currentUser) {
+
+        Category category = categoryService.findAccessibleCategoryById(itemDTO.idCategory(), currentUser);
+
+        Unit unit = unitService.findAccessibleUnitById(itemDTO.idUnit(), currentUser);
+
+        Item item = itemMapper.toEntity(itemDTO, category, unit);
+
         isItemValid(item);
         auditService.setAuditData(item, true);
         itemRepository.save(item);
+
         return item;
     }
 
@@ -45,11 +61,12 @@ public class ItemService {
 
     public Optional<Item> findItem(Item item) {
         Optional<Item> foundItem = itemRepository.findByIdAndDeletedFalse(item.getId());
+
         if (foundItem.isPresent()) {
             return foundItem;
-        } else {
-            throw new NoSuchElementException("Item not found");
         }
+
+        throw new NoSuchElementException("Item not found");
     }
 
     public Item findById(Long id) {
@@ -60,16 +77,26 @@ public class ItemService {
     // TODO remove item by item || Use soft delete
     public void removeItem(Long id) {
         findById(id);
-        // auditService.softDelete(item);
         itemRepository.deleteById(id);
     }
 
-    public Item editItem(Item item) {
-        findById(item.getId());
-        isItemValid(item);
-        auditService.setAuditData(item, false);
-        itemRepository.save(item);
-        return item;
+    public Item editItem(Long id, ItemRequestDTO itemDTO, User currentUser) {
+
+        Item existingItem = findById(id);
+
+        Category category = categoryService.findAccessibleCategoryById(itemDTO.idCategory(), currentUser);
+
+        Unit unit = unitService.findAccessibleUnitById(itemDTO.idUnit(), currentUser);
+
+        existingItem.setName(itemDTO.name());
+        existingItem.setCategory(category);
+        existingItem.setUnit(unit);
+
+        isItemValid(existingItem);
+        auditService.setAuditData(existingItem, false);
+        itemRepository.save(existingItem);
+
+        return existingItem;
     }
 
     public List<Item> findAll() {

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/list/controller/ListItemController.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/list/controller/ListItemController.java
@@ -47,8 +47,7 @@ public class ListItemController {
     public ResponseEntity<ListItemResponseDTO> getListItemById(@PathVariable Long listId, @PathVariable Long id,
             @AuthenticationPrincipal User user) {
 
-        ListItem listItem = service.findListItemById(listId, id, user);
-
+        ListItem listItem = service.findListItemByIdForRead(listId, id, user);
         ListItemResponseDTO responseDTO = listItemMapper.toResponseDTO(listItem);
         return HttpResponseUtil.ok(responseDTO);
     }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/list/controller/ShoppingListController.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/list/controller/ShoppingListController.java
@@ -53,7 +53,7 @@ public class ShoppingListController {
     @GetMapping("/{id}")
     public ResponseEntity<ShoppingListResponseDTO> getShoppingListById(@PathVariable Long id,
             @AuthenticationPrincipal User user) {
-        ShoppingList shoppingList = service.findAndVerifyAccess(id, user);
+        ShoppingList shoppingList = service.findAndVerifyReadAccess(id, user);
         ShoppingListResponseDTO responseDTO = listMapper.toResponseDTO(shoppingList);
         return HttpResponseUtil.ok(responseDTO);
     }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/list/repository/ListPermissionRepository.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/list/repository/ListPermissionRepository.java
@@ -15,4 +15,7 @@ public interface ListPermissionRepository extends JpaRepository<ListPermission, 
 
     @EntityGraph(attributePaths = { "user", "shoppingList", "shoppingList.owner" })
     Optional<ListPermission> findByIdAndDeletedFalse(Long id);
+
+    @EntityGraph(attributePaths = { "user", "shoppingList", "shoppingList.owner" })
+    Optional<ListPermission> findByShoppingListIdAndUserIdAndDeletedFalse(Long shoppingListId, Long userId);
 }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/list/service/ListItemService.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/list/service/ListItemService.java
@@ -39,9 +39,7 @@ public class ListItemService {
 
     public ListItem addShoppItemList(ListItemRequestDTO listItemRequestDTO, User user) {
         Item item = itemService.findById(listItemRequestDTO.itemId());
-        ShoppingList shoppingList = shoppingListService.findListById(listItemRequestDTO.listId());
-        shoppingListService.verifyOwnership(listItemRequestDTO.listId(), user);
-
+        ShoppingList shoppingList = shoppingListService.findAndVerifyWriteAccess(listItemRequestDTO.listId(), user);
         ListItem listItem = listItemMapper.toEntity(listItemRequestDTO, item, shoppingList);
 
         isListItemValid(listItem);
@@ -63,23 +61,30 @@ public class ListItemService {
         }
     }
 
-    public ListItem findListItemById(Long listId, Long id, User user) {
-        // Verify access first to prevent existence leakage
-        shoppingListService.verifyOwnership(listId, user);
+    public ListItem findListItemByIdForRead(Long listId, Long id, User user) {
 
-        // Query constrained by shoppListId - fails if item doesn't belong to the authorized list
+        shoppingListService.findAndVerifyReadAccess(listId, user);
+
+        return listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(id, listId)
+                .orElseThrow(() -> new NoSuchElementException("ListItem not found"));
+    }
+
+    public ListItem findListItemByIdForWrite(Long listId, Long id, User user) {
+
+        shoppingListService.findAndVerifyWriteAccess(listId, user);
+
         return listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(id, listId)
                 .orElseThrow(() -> new NoSuchElementException("ListItem not found"));
     }
 
     public void removeList(Long listId, Long id, User user) {
-        ListItem deletedItem = findListItemById(listId, id, user);
+        ListItem deletedItem = findListItemByIdForWrite(listId, id, user);
         auditService.softDelete(deletedItem);
         listItemRepository.save(deletedItem);
     }
 
     public ListItem editList(Long listId, Long id, ListItemUpdateRequestDTO listItemUpdateRequestDTO, User user) {
-        ListItem existingListItem = findListItemById(listId, id, user);
+        ListItem existingListItem = findListItemByIdForWrite(listId, id, user);
 
         existingListItem.setQuantity(listItemUpdateRequestDTO.quantity());
         existingListItem.setPurchased(listItemUpdateRequestDTO.purchased());
@@ -91,7 +96,8 @@ public class ListItemService {
     }
 
     public List<ListItem> findAll(Long idList, User user) {
-        shoppingListService.verifyOwnership(idList, user);
+        shoppingListService.findAndVerifyReadAccess(idList, user);
+
         return listItemRepository.findByShoppListIdAndDeletedFalse(idList);
     }
 }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/list/service/ListPermissionService.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/list/service/ListPermissionService.java
@@ -40,12 +40,8 @@ public class ListPermissionService {
     }
 
     public ListPermission addListPermission(ListPermissionRequestDTO listPermissionRequestDTO, User requester) {
-        ShoppingList shoppingList = shoppingListService.findListById(listPermissionRequestDTO.idList());
-
-        if (!shoppingList.getOwner().getId().equals(requester.getId())) {
-            throw new ResourceOwnershipException(
-                    "User does not have permission to grant access to this list. Only the list owner can grant permissions.");
-        }
+        ShoppingList shoppingList = shoppingListService.findAndVerifyOwnership(listPermissionRequestDTO.idList(),
+                requester);
 
         User user = userService.findUserById(listPermissionRequestDTO.idUser());
 
@@ -75,9 +71,7 @@ public class ListPermissionService {
         ListPermission listPermission = listPermissionRepository.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new NoSuchElementException("ListPermission not found"));
 
-        if (!listPermission.getShoppingList().getOwner().getId().equals(user.getId())) {
-            throw new ResourceOwnershipException("Only the list owner can manage permissions");
-        }
+        shoppingListService.findAndVerifyOwnership(listPermission.getShoppingList().getId(), user);
 
         return listPermission;
     }
@@ -98,11 +92,7 @@ public class ListPermissionService {
     }
 
     public List<ListPermission> findAllPermissionsByListId(Long id, User user) {
-        ShoppingList list = shoppingListService.findAndVerifyAccess(id, user);
-
-        if (!list.getOwner().getId().equals(user.getId())) {
-            throw new ResourceOwnershipException("Only the list owner can view permissions");
-        }
+        shoppingListService.findAndVerifyOwnership(id, user);
 
         return listPermissionRepository.findByShoppingListIdAndDeletedFalse(id);
     }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/list/service/ShoppingListService.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/list/service/ShoppingListService.java
@@ -4,6 +4,9 @@ import com.omatheusmesmo.shoppmate.list.dtos.ShoppingListUpdateRequestDTO;
 import com.omatheusmesmo.shoppmate.list.entity.ShoppingList;
 import com.omatheusmesmo.shoppmate.list.mapper.ListMapper;
 import com.omatheusmesmo.shoppmate.list.repository.ShoppingListRepository;
+import com.omatheusmesmo.shoppmate.list.entity.ListPermission;
+import com.omatheusmesmo.shoppmate.list.entity.Permission;
+import com.omatheusmesmo.shoppmate.list.repository.ListPermissionRepository;
 import com.omatheusmesmo.shoppmate.shared.service.AuditService;
 import com.omatheusmesmo.shoppmate.user.entity.User;
 import com.omatheusmesmo.shoppmate.user.service.UserService;
@@ -19,15 +22,27 @@ public class ShoppingListService {
 
     private final ShoppingListRepository shoppingListRepository;
 
+    private final ListPermissionRepository listPermissionRepository;
+
     private final AuditService auditService;
 
     private final UserService userService;
 
     private final ListMapper listMapper;
 
-    public ShoppingListService(ShoppingListRepository shoppingListRepository, AuditService auditService,
-            UserService userService, ListMapper listMapper) {
+    private boolean isOwner(ShoppingList shoppingList, User user) {
+        return shoppingList.getOwner().getId().equals(user.getId());
+    }
+
+    private Optional<ListPermission> findUserPermission(Long listId, User user) {
+        return listPermissionRepository.findByShoppingListIdAndUserIdAndDeletedFalse(listId, user.getId());
+    }
+
+    public ShoppingListService(ShoppingListRepository shoppingListRepository,
+            ListPermissionRepository listPermissionRepository, AuditService auditService, UserService userService,
+            ListMapper listMapper) {
         this.shoppingListRepository = shoppingListRepository;
+        this.listPermissionRepository = listPermissionRepository;
         this.auditService = auditService;
         this.userService = userService;
         this.listMapper = listMapper;
@@ -60,33 +75,30 @@ public class ShoppingListService {
 
     // TODO: implement soft delete?
     public void removeList(Long id, User currentLoggedUser) {
-        ShoppingList shoppingList = findAndVerifyAccess(id, currentLoggedUser);
-
-        // Only the owner can delete the list
-        if (!shoppingList.getOwner().getId().equals(currentLoggedUser.getId())) {
-            throw new ResourceOwnershipException("You can only delete your own shopping lists!");
-        }
-
+        findAndVerifyOwnership(id, currentLoggedUser);
         shoppingListRepository.deleteById(id);
     }
 
-    public ShoppingList editList(ShoppingList ShoppingList, User currentLoggedUser) {
-        findAndVerifyAccess(ShoppingList.getId(), currentLoggedUser);
+    public ShoppingList editList(ShoppingList shoppingList, User currentLoggedUser) {
+        findAndVerifyOwnership(shoppingList.getId(), currentLoggedUser);
 
-        return editListWithoutVerification(ShoppingList);
+        return editListWithoutVerification(shoppingList);
     }
 
     public ShoppingList editList(Long id, ShoppingListUpdateRequestDTO dto, User currentLoggedUser) {
-        ShoppingList existingList = findAndVerifyAccess(id, currentLoggedUser);
+
+        ShoppingList existingList = findAndVerifyOwnership(id, currentLoggedUser);
+
         listMapper.updateEntityFromDto(dto, existingList);
+
         return editListWithoutVerification(existingList);
     }
 
-    private ShoppingList editListWithoutVerification(ShoppingList ShoppingList) {
-        isListValid(ShoppingList);
-        auditService.setAuditData(ShoppingList, false);
-        shoppingListRepository.save(ShoppingList);
-        return ShoppingList;
+    private ShoppingList editListWithoutVerification(ShoppingList shoppingList) {
+        isListValid(shoppingList);
+        auditService.setAuditData(shoppingList, false);
+        shoppingListRepository.save(shoppingList);
+        return shoppingList;
     }
 
     public List<ShoppingList> findAll() {
@@ -97,21 +109,48 @@ public class ShoppingListService {
         return shoppingListRepository.findAllAccessibleByUserId(user.getId());
     }
 
-    public ShoppingList findAndVerifyAccess(Long listId, User user) {
+    public ShoppingList findAndVerifyReadAccess(Long listId, User user) {
         ShoppingList shoppingList = findListById(listId);
 
-        if (!shoppingList.getOwner().getId().equals(user.getId())) {
-            throw new ResourceOwnershipException("Access Denied: You do not have permission to access this list.");
+        if (isOwner(shoppingList, user)) {
+            return shoppingList;
+        }
+
+        ListPermission permission = findUserPermission(listId, user)
+                .orElseThrow(() -> new ResourceOwnershipException("You do not have permission to access this list."));
+
+        if (permission.getPermission() != Permission.READ && permission.getPermission() != Permission.WRITE) {
+            throw new ResourceOwnershipException("You do not have permission to access this list.");
         }
 
         return shoppingList;
     }
 
-    public void verifyOwnership(Long listId, User user) {
+    public ShoppingList findAndVerifyWriteAccess(Long listId, User user) {
         ShoppingList shoppingList = findListById(listId);
 
-        if (!shoppingList.getOwner().getId().equals(user.getId())) {
-            throw new ResourceOwnershipException("You do not have permission to access this resource");
+        if (isOwner(shoppingList, user)) {
+            return shoppingList;
         }
+
+        ListPermission permission = findUserPermission(listId, user)
+                .orElseThrow(() -> new ResourceOwnershipException("You do not have write permission for this list."));
+
+        if (permission.getPermission() != Permission.WRITE) {
+            throw new ResourceOwnershipException("You do not have write permission for this list.");
+        }
+
+        return shoppingList;
     }
+
+    public ShoppingList findAndVerifyOwnership(Long listId, User user) {
+        ShoppingList shoppingList = findListById(listId);
+
+        if (!isOwner(shoppingList, user)) {
+            throw new ResourceOwnershipException("Only the list owner may perform this operation.");
+        }
+
+        return shoppingList;
+    }
+
 }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/unit/repository/UnitRepository.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/unit/repository/UnitRepository.java
@@ -20,4 +20,17 @@ public interface UnitRepository extends JpaRepository<Unit, Long> {
 
     @Query("SELECT u FROM Unit u LEFT JOIN u.owner o WHERE u.deleted = false AND (u.isSystemStandard = true OR o.id = :userId)")
     List<Unit> findAllAccessibleByUserId(@Param("userId") Long userId);
+
+    @Query("""
+            SELECT u
+            FROM Unit u
+            LEFT JOIN u.owner o
+            WHERE u.id = :unitId
+              AND u.deleted = false
+              AND (
+                  u.isSystemStandard = true
+                  OR o.id = :userId
+              )
+            """)
+    Optional<Unit> findAccessibleByIdAndUserId(@Param("unitId") Long unitId, @Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/omatheusmesmo/shoppmate/unit/service/UnitService.java
+++ b/backend/src/main/java/com/omatheusmesmo/shoppmate/unit/service/UnitService.java
@@ -85,4 +85,10 @@ public class UnitService {
             throw new IllegalArgumentException("Enter a valid unit symbol!");
         }
     }
+
+    public Unit findAccessibleUnitById(Long id, User currentUser) {
+
+        return unitRepository.findAccessibleByIdAndUserId(id, currentUser.getId())
+                .orElseThrow(() -> new NoSuchElementException("Unit not found with id: " + id));
+    }
 }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/category/controller/CategoryControllerTest.java
@@ -133,14 +133,18 @@ class CategoryControllerTest {
 
         CategoryResponseDTO responseDTO = new CategoryResponseDTO(id, updatedName, false, null);
 
-        when(categoryMapper.toEntity(any(CategoryRequestDTO.class), any(User.class))).thenReturn(category1);
-        doNothing().when(categoryService).editCategory(eq(id), any(CategoryRequestDTO.class), any(User.class));
-        when(categoryService.findCategoryById(id)).thenReturn(updatedCategory);
+        when(categoryService.editCategory(eq(id), any(CategoryRequestDTO.class), any(User.class)))
+                .thenReturn(updatedCategory);
+
         when(categoryMapper.toResponseDTO(updatedCategory)).thenReturn(responseDTO);
 
         // Act & Assert
         mockMvc.perform(put("/category/{id}", id).contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(requestDTO))).andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(responseDTO)));
+
+        verify(categoryService).editCategory(eq(id), eq(requestDTO), any(User.class));
+
+        verify(categoryMapper).toResponseDTO(updatedCategory);
     }
 }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/category/repository/CategoryRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/category/repository/CategoryRepositoryIntegrationTest.java
@@ -8,12 +8,14 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.omatheusmesmo.shoppmate.category.entity.Category;
 import com.omatheusmesmo.shoppmate.shared.testcontainers.AbstractIntegrationTest;
 import com.omatheusmesmo.shoppmate.user.entity.User;
 import com.omatheusmesmo.shoppmate.user.repository.UserRepository;
 
+@Transactional
 class CategoryRepositoryIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
@@ -27,9 +29,6 @@ class CategoryRepositoryIntegrationTest extends AbstractIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        categoryRepository.deleteAll();
-        userRepository.deleteAll();
-
         currentUser = createUser("current-user@example.com");
         otherUser = createUser("other-user@example.com");
     }
@@ -88,7 +87,6 @@ class CategoryRepositoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     private Category createCategory(String name, User owner, boolean systemStandard, boolean deleted) {
-
         Category category = new Category();
         category.setName(name);
         category.setOwner(owner);

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/category/repository/CategoryRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/category/repository/CategoryRepositoryIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.omatheusmesmo.shoppmate.category.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.omatheusmesmo.shoppmate.category.entity.Category;
+import com.omatheusmesmo.shoppmate.shared.testcontainers.AbstractIntegrationTest;
+import com.omatheusmesmo.shoppmate.user.entity.User;
+import com.omatheusmesmo.shoppmate.user.repository.UserRepository;
+
+class CategoryRepositoryIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User currentUser;
+    private User otherUser;
+
+    @BeforeEach
+    void setUp() {
+        categoryRepository.deleteAll();
+        userRepository.deleteAll();
+
+        currentUser = createUser("current-user@example.com");
+        otherUser = createUser("other-user@example.com");
+    }
+
+    @Test
+    void findAccessibleByIdAndUserId_OwnCategory_ReturnsCategory() {
+        Category category = createCategory("Own Category", currentUser, false, false);
+
+        Optional<Category> result = categoryRepository.findAccessibleByIdAndUserId(category.getId(),
+                currentUser.getId());
+
+        assertTrue(result.isPresent());
+        assertEquals(category.getId(), result.get().getId());
+    }
+
+    @Test
+    void findAccessibleByIdAndUserId_SystemCategory_ReturnsCategory() {
+        Category category = createCategory("System Category", null, true, false);
+
+        Optional<Category> result = categoryRepository.findAccessibleByIdAndUserId(category.getId(),
+                currentUser.getId());
+
+        assertTrue(result.isPresent());
+        assertEquals(category.getId(), result.get().getId());
+    }
+
+    @Test
+    void findAccessibleByIdAndUserId_OtherUsersCategory_ReturnsEmpty() {
+        Category category = createCategory("Other User Category", otherUser, false, false);
+
+        Optional<Category> result = categoryRepository.findAccessibleByIdAndUserId(category.getId(),
+                currentUser.getId());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findAccessibleByIdAndUserId_DeletedOwnedCategory_ReturnsEmpty() {
+        Category category = createCategory("Deleted Category", currentUser, false, true);
+
+        Optional<Category> result = categoryRepository.findAccessibleByIdAndUserId(category.getId(),
+                currentUser.getId());
+
+        assertTrue(result.isEmpty());
+    }
+
+    private User createUser(String email) {
+        User user = new User();
+        user.setEmail(email);
+        user.setFullName("Repository Test User");
+        user.setPassword("password");
+        user.setRole("USER");
+        user.setDeleted(false);
+
+        return userRepository.save(user);
+    }
+
+    private Category createCategory(String name, User owner, boolean systemStandard, boolean deleted) {
+
+        Category category = new Category();
+        category.setName(name);
+        category.setOwner(owner);
+        category.setSystemStandard(systemStandard);
+        category.setDeleted(deleted);
+
+        return categoryRepository.save(category);
+    }
+}

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/category/service/CategoryServiceTest.java
@@ -174,4 +174,32 @@ class CategoryServiceTest {
         // Act & Assert - no exception expected
         categoryService.verifyOwnershipOrSystem(category, user);
     }
+
+    @Test
+    void findAccessibleCategoryById_AccessibleCategory_ReturnsCategory() {
+        // Arrange
+        when(categoryRepository.findAccessibleByIdAndUserId(category.getId(), user.getId()))
+                .thenReturn(Optional.of(category));
+
+        // Act
+        Category result = categoryService.findAccessibleCategoryById(category.getId(), user);
+
+        // Assert
+        assertEquals(category, result);
+
+        verify(categoryRepository).findAccessibleByIdAndUserId(category.getId(), user.getId());
+    }
+
+    @Test
+    void findAccessibleCategoryById_InaccessibleCategory_ThrowsNoSuchElementException() {
+        // Arrange
+        when(categoryRepository.findAccessibleByIdAndUserId(category.getId(), user.getId()))
+                .thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(NoSuchElementException.class,
+                () -> categoryService.findAccessibleCategoryById(category.getId(), user));
+
+        verify(categoryRepository).findAccessibleByIdAndUserId(category.getId(), user.getId());
+    }
 }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/item/controller/ItemControllerTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/item/controller/ItemControllerTest.java
@@ -1,15 +1,15 @@
 package com.omatheusmesmo.shoppmate.item.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.omatheusmesmo.shoppmate.auth.service.JwtService;
 import com.omatheusmesmo.shoppmate.category.dto.CategoryResponseDTO;
 import com.omatheusmesmo.shoppmate.item.dto.ItemRequestDTO;
 import com.omatheusmesmo.shoppmate.item.dto.ItemResponseDTO;
 import com.omatheusmesmo.shoppmate.item.entity.Item;
 import com.omatheusmesmo.shoppmate.item.mapper.ItemMapper;
+import com.omatheusmesmo.shoppmate.item.service.ItemService;
 import com.omatheusmesmo.shoppmate.shared.testutils.ItemTestFactory;
 import com.omatheusmesmo.shoppmate.unit.dto.UnitResponseDTO;
-import com.omatheusmesmo.shoppmate.item.service.ItemService;
-import com.omatheusmesmo.shoppmate.auth.service.JwtService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -27,8 +27,16 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -63,6 +71,7 @@ class ItemControllerTest {
     void setUp() {
         item1 = ItemTestFactory.createValidItem();
         item2 = ItemTestFactory.createValidItem();
+
         // Ensure unique IDs
         if (item1.getId().equals(item2.getId())) {
             item2.setId(item1.getId() + 1);
@@ -70,14 +79,18 @@ class ItemControllerTest {
 
         CategoryResponseDTO categoryDTO1 = new CategoryResponseDTO(item1.getCategory().getId(),
                 item1.getCategory().getName(), false, null);
+
         UnitResponseDTO unitDTO1 = new UnitResponseDTO(item1.getUnit().getId(), item1.getUnit().getName(),
                 item1.getUnit().getSymbol(), false, null);
+
         itemResponseDTO1 = new ItemResponseDTO(item1.getId(), item1.getName(), categoryDTO1, unitDTO1);
 
         CategoryResponseDTO categoryDTO2 = new CategoryResponseDTO(item2.getCategory().getId(),
                 item2.getCategory().getName(), false, null);
+
         UnitResponseDTO unitDTO2 = new UnitResponseDTO(item2.getUnit().getId(), item2.getUnit().getName(),
                 item2.getUnit().getSymbol(), false, null);
+
         itemResponseDTO2 = new ItemResponseDTO(item2.getId(), item2.getName(), categoryDTO2, unitDTO2);
     }
 
@@ -89,10 +102,14 @@ class ItemControllerTest {
         List<ItemResponseDTO> allItemDTOs = Arrays.asList(itemResponseDTO1, itemResponseDTO2);
 
         when(itemService.findAll()).thenReturn(allItems);
+
         when(itemMapper.toResponseDTO(any(Item.class))).thenAnswer(invocation -> {
             Item item = invocation.getArgument(0);
-            if (item.getId().equals(item1.getId()))
+
+            if (item.getId().equals(item1.getId())) {
                 return itemResponseDTO1;
+            }
+
             return itemResponseDTO2;
         });
 
@@ -108,8 +125,8 @@ class ItemControllerTest {
         ItemRequestDTO requestDTO = new ItemRequestDTO(item1.getName(), item1.getCategory().getId(),
                 item1.getUnit().getId());
 
-        when(itemMapper.toEntity(any(ItemRequestDTO.class))).thenReturn(item1);
-        when(itemService.addItem(any(Item.class))).thenReturn(item1);
+        when(itemService.addItem(any(ItemRequestDTO.class), isNull())).thenReturn(item1);
+
         when(itemMapper.toResponseDTO(any(Item.class))).thenReturn(itemResponseDTO1);
 
         // Act & Assert
@@ -123,10 +140,12 @@ class ItemControllerTest {
     void testDeleteRemoveItem() throws Exception {
         // Arrange
         Long id = item1.getId();
+
         Mockito.doNothing().when(itemService).removeItem(id);
 
         // Act & Assert
         mockMvc.perform(delete("/item/" + id)).andExpect(status().isNoContent());
+
         verify(itemService, times(1)).removeItem(id);
     }
 
@@ -137,8 +156,8 @@ class ItemControllerTest {
         ItemRequestDTO requestDTO = new ItemRequestDTO(item1.getName(), item1.getCategory().getId(),
                 item1.getUnit().getId());
 
-        when(itemMapper.toEntity(any(ItemRequestDTO.class))).thenReturn(item1);
-        when(itemService.editItem(any(Item.class))).thenReturn(item1);
+        when(itemService.editItem(eq(item1.getId()), any(ItemRequestDTO.class), isNull())).thenReturn(item1);
+
         when(itemMapper.toResponseDTO(any(Item.class))).thenReturn(itemResponseDTO1);
 
         // Act & Assert
@@ -151,8 +170,6 @@ class ItemControllerTest {
     @WithMockUser
     void testPostAddItem_BadRequest() throws Exception {
         // Arrange
-        when(itemMapper.toEntity(any(ItemRequestDTO.class))).thenThrow(new IllegalArgumentException("Invalid item"));
-
         ItemRequestDTO invalidItem = new ItemRequestDTO("", item1.getCategory().getId(), item1.getUnit().getId());
 
         // Act & Assert
@@ -167,8 +184,8 @@ class ItemControllerTest {
         ItemRequestDTO requestDTO = new ItemRequestDTO(item1.getName(), item1.getCategory().getId(),
                 item1.getUnit().getId());
 
-        when(itemMapper.toEntity(any(ItemRequestDTO.class))).thenReturn(item1);
-        doThrow(new NoSuchElementException()).when(itemService).editItem(any(Item.class));
+        doThrow(new NoSuchElementException()).when(itemService).editItem(eq(item1.getId()), any(ItemRequestDTO.class),
+                isNull());
 
         // Act & Assert
         mockMvc.perform(put("/item/" + item1.getId()).contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/item/service/ItemServiceTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/item/service/ItemServiceTest.java
@@ -2,13 +2,15 @@ package com.omatheusmesmo.shoppmate.item.service;
 
 import com.omatheusmesmo.shoppmate.category.entity.Category;
 import com.omatheusmesmo.shoppmate.category.service.CategoryService;
+import com.omatheusmesmo.shoppmate.item.dto.ItemRequestDTO;
 import com.omatheusmesmo.shoppmate.item.entity.Item;
-import com.omatheusmesmo.shoppmate.item.service.ItemService;
-import com.omatheusmesmo.shoppmate.unit.entity.Unit;
+import com.omatheusmesmo.shoppmate.item.mapper.ItemMapper;
 import com.omatheusmesmo.shoppmate.item.repository.ItemRepository;
 import com.omatheusmesmo.shoppmate.shared.service.AuditService;
 import com.omatheusmesmo.shoppmate.shared.testutils.ItemTestFactory;
+import com.omatheusmesmo.shoppmate.unit.entity.Unit;
 import com.omatheusmesmo.shoppmate.unit.service.UnitService;
+import com.omatheusmesmo.shoppmate.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -20,8 +22,16 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ItemServiceTest {
 
@@ -37,30 +47,103 @@ class ItemServiceTest {
     @Mock
     private CategoryService categoryService;
 
+    @Mock
+    private ItemMapper itemMapper;
+
     @InjectMocks
     private ItemService itemService;
+
+    private User currentUser;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+
+        currentUser = new User();
+        currentUser.setId(1L);
     }
 
     @Test
-    void addItem_ValidItem_ReturnsSavedItem() {
+    void addItem_AccessibleCategoryAndUnit_ReturnsSavedItem() {
         // Arrange
         Item item = createSampleItem();
+
+        Category category = item.getCategory();
+        Unit unit = item.getUnit();
+
+        ItemRequestDTO requestDTO = new ItemRequestDTO(item.getName(), category.getId(), unit.getId());
+
+        when(categoryService.findAccessibleCategoryById(requestDTO.idCategory(), currentUser)).thenReturn(category);
+
+        when(unitService.findAccessibleUnitById(requestDTO.idUnit(), currentUser)).thenReturn(unit);
+
+        when(itemMapper.toEntity(requestDTO, category, unit)).thenReturn(item);
+
         when(itemRepository.save(item)).thenReturn(item);
 
         // Act
-        Item result = itemService.addItem(item);
+        Item result = itemService.addItem(requestDTO, currentUser);
 
         // Assert
         assertNotNull(result);
         assertEquals(item, result);
-        verify(categoryService, times(1)).isCategoryValid(item.getCategory());
-        verify(unitService, times(1)).isUnitValid(item.getUnit());
-        verify(auditService, times(1)).setAuditData(item, true);
-        verify(itemRepository, times(1)).save(item);
+
+        verify(categoryService).findAccessibleCategoryById(requestDTO.idCategory(), currentUser);
+
+        verify(unitService).findAccessibleUnitById(requestDTO.idUnit(), currentUser);
+
+        verify(itemMapper).toEntity(requestDTO, category, unit);
+
+        verify(categoryService).isCategoryValid(category);
+
+        verify(unitService).isUnitValid(unit);
+
+        verify(auditService).setAuditData(item, true);
+
+        verify(itemRepository).save(item);
+    }
+
+    @Test
+    void addItem_InaccessibleCategory_DoesNotSaveItem() {
+        // Arrange
+        Item item = createSampleItem();
+
+        ItemRequestDTO requestDTO = new ItemRequestDTO(item.getName(), item.getCategory().getId(),
+                item.getUnit().getId());
+
+        when(categoryService.findAccessibleCategoryById(requestDTO.idCategory(), currentUser))
+                .thenThrow(new NoSuchElementException("Category not found"));
+
+        // Act & Assert
+        assertThrows(NoSuchElementException.class, () -> itemService.addItem(requestDTO, currentUser));
+
+        verify(unitService, never()).findAccessibleUnitById(any(), any());
+
+        verify(itemMapper, never()).toEntity(any(), any(), any());
+
+        verify(itemRepository, never()).save(any());
+    }
+
+    @Test
+    void addItem_InaccessibleUnit_DoesNotSaveItem() {
+        // Arrange
+        Item item = createSampleItem();
+
+        Category category = item.getCategory();
+
+        ItemRequestDTO requestDTO = new ItemRequestDTO(item.getName(), category.getId(), item.getUnit().getId());
+
+        when(categoryService.findAccessibleCategoryById(requestDTO.idCategory(), currentUser)).thenReturn(category);
+
+        when(unitService.findAccessibleUnitById(requestDTO.idUnit(), currentUser))
+                .thenThrow(new NoSuchElementException("Unit not found"));
+
+        // Act & Assert
+        assertThrows(NoSuchElementException.class, () -> itemService.addItem(requestDTO, currentUser));
+
+        verify(itemMapper, never()).toEntity(any(), any(), any());
+
+        verify(itemRepository, never()).save(any());
     }
 
     @Test
@@ -70,14 +153,17 @@ class ItemServiceTest {
 
         // Act & Assert
         assertDoesNotThrow(() -> itemService.isItemValid(item));
-        verify(categoryService, times(1)).isCategoryValid(item.getCategory());
-        verify(unitService, times(1)).isUnitValid(item.getUnit());
+
+        verify(categoryService).isCategoryValid(item.getCategory());
+
+        verify(unitService).isUnitValid(item.getUnit());
     }
 
     @Test
     void findItem_ExistingItem_ReturnsItem() {
         // Arrange
         Item item = createSampleItem();
+
         when(itemRepository.findByIdAndDeletedFalse(item.getId())).thenReturn(Optional.of(item));
 
         // Act
@@ -86,26 +172,31 @@ class ItemServiceTest {
         // Assert
         assertTrue(result.isPresent());
         assertEquals(item, result.get());
-        verify(itemRepository, times(1)).findByIdAndDeletedFalse(item.getId());
+
+        verify(itemRepository).findByIdAndDeletedFalse(item.getId());
     }
 
     @Test
     void findItem_NonExistingItem_ThrowsNoSuchElementException() {
         // Arrange
         Item item = createSampleItem();
+
         when(itemRepository.findByIdAndDeletedFalse(item.getId())).thenReturn(Optional.empty());
 
         // Act & Assert
         assertThrows(NoSuchElementException.class, () -> itemService.findItem(item));
-        verify(itemRepository, times(1)).findByIdAndDeletedFalse(item.getId());
+
+        verify(itemRepository).findByIdAndDeletedFalse(item.getId());
     }
 
     @Test
     void findItemById_ExistingId_ReturnsItem() {
         // Arrange
         Long id = 1L;
+
         Item item = createSampleItem();
         item.setId(id);
+
         when(itemRepository.findByIdWithRelations(id)).thenReturn(Optional.of(item));
 
         // Act
@@ -113,77 +204,124 @@ class ItemServiceTest {
 
         // Assert
         assertEquals(item, result);
-        verify(itemRepository, times(1)).findByIdWithRelations(id);
+
+        verify(itemRepository).findByIdWithRelations(id);
     }
 
     @Test
     void findItemById_NonExistingId_ThrowsNoSuchElementException() {
         // Arrange
         Long id = 1L;
+
         when(itemRepository.findByIdWithRelations(id)).thenReturn(Optional.empty());
 
         // Act & Assert
         assertThrows(NoSuchElementException.class, () -> itemService.findById(id));
-        verify(itemRepository, times(1)).findByIdWithRelations(id);
+
+        verify(itemRepository).findByIdWithRelations(id);
     }
 
     @Test
     void removeItem_ExistingId_DeletesItem() {
         // Arrange
         Long id = 1L;
+
         Item item = createSampleItem();
         item.setId(id);
+
         when(itemRepository.findByIdWithRelations(id)).thenReturn(Optional.of(item));
 
         // Act
         itemService.removeItem(id);
 
         // Assert
-        verify(itemRepository, times(1)).findByIdWithRelations(id);
-        verify(itemRepository, times(1)).deleteById(id);
+        verify(itemRepository).findByIdWithRelations(id);
+
+        verify(itemRepository).deleteById(id);
     }
 
     @Test
     void removeItem_NonExistingId_ThrowsNoSuchElementException() {
         // Arrange
         Long id = 1L;
+
         when(itemRepository.findByIdWithRelations(id)).thenReturn(Optional.empty());
 
         // Act & Assert
         assertThrows(NoSuchElementException.class, () -> itemService.removeItem(id));
-        verify(itemRepository, times(1)).findByIdWithRelations(id);
+
+        verify(itemRepository).findByIdWithRelations(id);
+
         verify(itemRepository, never()).deleteById(any());
     }
 
     @Test
-    void editItem_ExistingItem_ReturnsEditedItem() {
+    void editItem_ExistingItemAndAccessibleReferences_ReturnsEditedItem() {
         // Arrange
-        Item item = createSampleItem();
-        when(itemRepository.findByIdWithRelations(item.getId())).thenReturn(Optional.of(item));
-        when(itemRepository.save(item)).thenReturn(item);
+        Long id = 1L;
+
+        Item existingItem = createSampleItem();
+        existingItem.setId(id);
+
+        Category category = existingItem.getCategory();
+        Unit unit = existingItem.getUnit();
+
+        ItemRequestDTO requestDTO = new ItemRequestDTO("Updated item", category.getId(), unit.getId());
+
+        when(itemRepository.findByIdWithRelations(id)).thenReturn(Optional.of(existingItem));
+
+        when(categoryService.findAccessibleCategoryById(requestDTO.idCategory(), currentUser)).thenReturn(category);
+
+        when(unitService.findAccessibleUnitById(requestDTO.idUnit(), currentUser)).thenReturn(unit);
+
+        when(itemRepository.save(existingItem)).thenReturn(existingItem);
 
         // Act
-        Item result = itemService.editItem(item);
+        Item result = itemService.editItem(id, requestDTO, currentUser);
 
         // Assert
         assertNotNull(result);
-        assertEquals(item, result);
-        verify(itemRepository, times(1)).findByIdWithRelations(item.getId());
-        verify(categoryService, times(1)).isCategoryValid(item.getCategory());
-        verify(unitService, times(1)).isUnitValid(item.getUnit());
-        verify(auditService, times(1)).setAuditData(item, false);
-        verify(itemRepository, times(1)).save(item);
+        assertEquals(existingItem, result);
+        assertEquals("Updated item", result.getName());
+        assertEquals(category, result.getCategory());
+        assertEquals(unit, result.getUnit());
+
+        verify(itemRepository).findByIdWithRelations(id);
+
+        verify(categoryService).findAccessibleCategoryById(requestDTO.idCategory(), currentUser);
+
+        verify(unitService).findAccessibleUnitById(requestDTO.idUnit(), currentUser);
+
+        verify(categoryService).isCategoryValid(category);
+
+        verify(unitService).isUnitValid(unit);
+
+        verify(auditService).setAuditData(existingItem, false);
+
+        verify(itemRepository).save(existingItem);
     }
 
     @Test
     void editItem_NonExistingItem_ThrowsNoSuchElementException() {
         // Arrange
+        Long id = 1L;
+
         Item item = createSampleItem();
-        when(itemRepository.findByIdWithRelations(item.getId())).thenReturn(Optional.empty());
+
+        ItemRequestDTO requestDTO = new ItemRequestDTO(item.getName(), item.getCategory().getId(),
+                item.getUnit().getId());
+
+        when(itemRepository.findByIdWithRelations(id)).thenReturn(Optional.empty());
 
         // Act & Assert
-        assertThrows(NoSuchElementException.class, () -> itemService.editItem(item));
-        verify(itemRepository, times(1)).findByIdWithRelations(item.getId());
+        assertThrows(NoSuchElementException.class, () -> itemService.editItem(id, requestDTO, currentUser));
+
+        verify(itemRepository).findByIdWithRelations(id);
+
+        verify(categoryService, never()).findAccessibleCategoryById(any(), any());
+
+        verify(unitService, never()).findAccessibleUnitById(any(), any());
+
         verify(itemRepository, never()).save(any());
     }
 
@@ -192,7 +330,9 @@ class ItemServiceTest {
         // Arrange
         Item item1 = createSampleItem();
         Item item2 = createSampleItem();
+
         List<Item> items = Arrays.asList(item1, item2);
+
         when(itemRepository.findAllByDeletedFalse()).thenReturn(items);
 
         // Act
@@ -202,6 +342,7 @@ class ItemServiceTest {
         assertEquals(2, result.size());
         assertTrue(result.contains(item1));
         assertTrue(result.contains(item2));
+
         verify(itemRepository, times(1)).findAllByDeletedFalse();
     }
 

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/list/controller/ListItemControllerSecurityIntegrationTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/list/controller/ListItemControllerSecurityIntegrationTest.java
@@ -8,16 +8,21 @@ import com.omatheusmesmo.shoppmate.item.entity.Item;
 import com.omatheusmesmo.shoppmate.item.repository.ItemRepository;
 import com.omatheusmesmo.shoppmate.list.dtos.ListItemRequestDTO;
 import com.omatheusmesmo.shoppmate.list.dtos.ListItemUpdateRequestDTO;
-import com.omatheusmesmo.shoppmate.list.mapper.ListMapper;
-import com.omatheusmesmo.shoppmate.unit.entity.Unit;
-import com.omatheusmesmo.shoppmate.unit.repository.UnitRepository;
 import com.omatheusmesmo.shoppmate.list.dtos.ShoppingListRequestDTO;
 import com.omatheusmesmo.shoppmate.list.entity.ListItem;
+import com.omatheusmesmo.shoppmate.list.entity.ListPermission;
+import com.omatheusmesmo.shoppmate.list.entity.Permission;
 import com.omatheusmesmo.shoppmate.list.entity.ShoppingList;
+import com.omatheusmesmo.shoppmate.list.mapper.ListMapper;
 import com.omatheusmesmo.shoppmate.list.repository.ListItemRepository;
+import com.omatheusmesmo.shoppmate.list.repository.ListPermissionRepository;
+import com.omatheusmesmo.shoppmate.list.repository.ShoppingListRepository;
 import com.omatheusmesmo.shoppmate.list.service.ListItemService;
 import com.omatheusmesmo.shoppmate.list.service.ShoppingListService;
 import com.omatheusmesmo.shoppmate.shared.testcontainers.AbstractIntegrationTest;
+import com.omatheusmesmo.shoppmate.shared.testutils.ListTestFactory;
+import com.omatheusmesmo.shoppmate.unit.entity.Unit;
+import com.omatheusmesmo.shoppmate.unit.repository.UnitRepository;
 import com.omatheusmesmo.shoppmate.user.entity.User;
 import com.omatheusmesmo.shoppmate.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -29,8 +34,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
-import com.omatheusmesmo.shoppmate.list.repository.ShoppingListRepository;
-import com.omatheusmesmo.shoppmate.list.repository.ListPermissionRepository;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -86,10 +89,13 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     private User userA;
     private User userB;
+
     private ShoppingList userAList;
     private ShoppingList userAList2;
     private ShoppingList userBList;
+
     private Item item;
+
     private ListItem userAListItem;
     private ListItem userBListItem;
 
@@ -124,15 +130,21 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
         tokenUserB = jwtService.generateToken(userB);
 
         ShoppingListRequestDTO dtoA = new ShoppingListRequestDTO("User A's Shopping List");
+
         ShoppingList entityA = listMapper.toEntity(dtoA, userA);
+
         userAList = shoppingListService.saveList(entityA);
 
         ShoppingListRequestDTO dtoA2 = new ShoppingListRequestDTO("User A's Second Shopping List");
+
         ShoppingList entityA2 = listMapper.toEntity(dtoA2, userA);
+
         userAList2 = shoppingListService.saveList(entityA2);
 
         ShoppingListRequestDTO dtoB = new ShoppingListRequestDTO("User B's Shopping List");
+
         ShoppingList entityB = listMapper.toEntity(dtoB, userB);
+
         userBList = shoppingListService.saveList(entityB);
 
         Category category = new Category();
@@ -151,9 +163,11 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
         item = itemRepository.save(item);
 
         ListItemRequestDTO itemDTOA = new ListItemRequestDTO(userAList.getId(), item.getId(), 2, null);
+
         userAListItem = listItemService.addShoppItemList(itemDTOA, userA);
 
         ListItemRequestDTO itemDTOB = new ListItemRequestDTO(userBList.getId(), item.getId(), 1, null);
+
         userBListItem = listItemService.addShoppItemList(itemDTOB, userB);
     }
 
@@ -168,33 +182,87 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
         userRepository.deleteAll();
     }
 
+    private ListPermission grantPermission(ShoppingList shoppingList, User user, Permission permission) {
+
+        ListPermission listPermission = ListTestFactory.createValidListPermission(shoppingList);
+
+        listPermission.setShoppingList(shoppingList);
+        listPermission.setUser(user);
+        listPermission.setPermission(permission);
+
+        return listPermissionRepository.save(listPermission);
+    }
+
     @Test
     void testUserCannotGetAnotherUsersListItem() throws Exception {
+
         mockMvc.perform(get("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).header("Authorization",
                 "Bearer " + tokenUserA)).andExpect(status().isForbidden());
     }
 
     @Test
     void testUserCanGetOwnListItem() throws Exception {
+
         mockMvc.perform(get("/lists/" + userAList.getId() + "/items/" + userAListItem.getId()).header("Authorization",
                 "Bearer " + tokenUserA)).andExpect(status().isOk()).andExpect(jsonPath("$.quantity").value(2));
     }
 
     @Test
+    void testReadUserCanGetSharedListItem() throws Exception {
+
+        grantPermission(userBList, userA, Permission.READ);
+
+        mockMvc.perform(get("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).header("Authorization",
+                "Bearer " + tokenUserA)).andExpect(status().isOk()).andExpect(jsonPath("$.quantity").value(1));
+    }
+
+    @Test
+    void testWriteUserCanGetSharedListItem() throws Exception {
+
+        grantPermission(userBList, userA, Permission.WRITE);
+
+        mockMvc.perform(get("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).header("Authorization",
+                "Bearer " + tokenUserA)).andExpect(status().isOk()).andExpect(jsonPath("$.quantity").value(1));
+    }
+
+    @Test
     void testUserCannotGetAllItemsFromAnotherUsersList() throws Exception {
+
         mockMvc.perform(get("/lists/" + userBList.getId() + "/items").header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isForbidden()).andExpect(jsonPath("$.message").exists());
     }
 
     @Test
     void testUserCanGetAllItemsFromOwnList() throws Exception {
+
         mockMvc.perform(get("/lists/" + userAList.getId() + "/items").header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.size()").value(1))
                 .andExpect(jsonPath("$[0].quantity").value(2));
     }
 
     @Test
+    void testReadUserCanGetAllItemsFromSharedList() throws Exception {
+
+        grantPermission(userBList, userA, Permission.READ);
+
+        mockMvc.perform(get("/lists/" + userBList.getId() + "/items").header("Authorization", "Bearer " + tokenUserA))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.size()").value(1))
+                .andExpect(jsonPath("$[0].quantity").value(1));
+    }
+
+    @Test
+    void testWriteUserCanGetAllItemsFromSharedList() throws Exception {
+
+        grantPermission(userBList, userA, Permission.WRITE);
+
+        mockMvc.perform(get("/lists/" + userBList.getId() + "/items").header("Authorization", "Bearer " + tokenUserA))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.size()").value(1))
+                .andExpect(jsonPath("$[0].quantity").value(1));
+    }
+
+    @Test
     void testUserCannotAddItemToAnotherUsersList() throws Exception {
+
         ListItemRequestDTO maliciousDTO = new ListItemRequestDTO(userBList.getId(), item.getId(), 5, null);
 
         mockMvc.perform(post("/lists/" + userBList.getId() + "/items").with(csrf())
@@ -202,18 +270,55 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
                 .content(objectMapper.writeValueAsString(maliciousDTO))).andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.message").exists());
 
-        Iterable<ListItem> userBItems = listItemRepository.findAll();
-        long userBItemCount = 0;
-        for (ListItem li : userBItems) {
-            if (li.getShoppList().getId().equals(userBList.getId())) {
-                userBItemCount++;
-            }
-        }
-        assertEquals(1, userBItemCount, "User B's list should still have only 1 item");
+        assertEquals(1, countItemsForList(userBList.getId()));
+    }
+
+    @Test
+    void testReadUserCannotAddItemToSharedList() throws Exception {
+
+        grantPermission(userBList, userA, Permission.READ);
+
+        ListItemRequestDTO requestDTO = new ListItemRequestDTO(userBList.getId(), item.getId(), 5, null);
+
+        mockMvc.perform(post("/lists/" + userBList.getId() + "/items").with(csrf())
+                .header("Authorization", "Bearer " + tokenUserA).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO))).andExpect(status().isForbidden());
+
+        assertEquals(1, countItemsForList(userBList.getId()));
+    }
+
+    @Test
+    void testWriteUserCanAddItemToSharedList() throws Exception {
+
+        grantPermission(userBList, userA, Permission.WRITE);
+
+        Category category = new Category();
+        category.setName("Shared Bakery");
+        category = categoryRepository.save(category);
+
+        Unit unit = new Unit();
+        unit.setName("Shared Pieces");
+        unit.setSymbol("sp");
+        unit = unitRepository.save(unit);
+
+        Item newItem = new Item();
+        newItem.setName("Shared Bread");
+        newItem.setCategory(category);
+        newItem.setUnit(unit);
+        newItem = itemRepository.save(newItem);
+
+        ListItemRequestDTO requestDTO = new ListItemRequestDTO(userBList.getId(), newItem.getId(), 5, null);
+
+        mockMvc.perform(post("/lists/" + userBList.getId() + "/items").with(csrf())
+                .header("Authorization", "Bearer " + tokenUserA).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO))).andExpect(status().isCreated());
+
+        assertEquals(2, countItemsForList(userBList.getId()));
     }
 
     @Test
     void testUserCanAddItemToOwnList() throws Exception {
+
         Category category = new Category();
         category.setName("Bakery");
         category = categoryRepository.save(category);
@@ -235,39 +340,55 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
                 .header("Authorization", "Bearer " + tokenUserA).contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(validDTO))).andExpect(status().isCreated());
 
-        Iterable<ListItem> allItems = listItemRepository.findAll();
-        long userAItemCount = 0;
-        for (ListItem li : allItems) {
-            if (li.getShoppList().getId().equals(userAList.getId())) {
-                userAItemCount++;
-            }
-        }
-        assertEquals(2, userAItemCount, "User A's list should now have 2 items");
+        assertEquals(2, countItemsForList(userAList.getId()));
     }
 
     @Test
     void testUserCannotDeleteAnotherUsersListItem() throws Exception {
+
         mockMvc.perform(delete("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).with(csrf())
                 .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.message").exists());
 
-        assertTrue(listItemRepository.findById(userBListItem.getId()).isPresent(),
-                "User B's list item should still exist");
+        assertFalse(listItemRepository.findById(userBListItem.getId()).orElseThrow().getDeleted());
+    }
+
+    @Test
+    void testReadUserCannotDeleteSharedListItem() throws Exception {
+
+        grantPermission(userBList, userA, Permission.READ);
+
+        mockMvc.perform(delete("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).with(csrf())
+                .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isForbidden());
+
+        assertFalse(listItemRepository.findById(userBListItem.getId()).orElseThrow().getDeleted());
+    }
+
+    @Test
+    void testWriteUserCanDeleteSharedListItem() throws Exception {
+
+        grantPermission(userBList, userA, Permission.WRITE);
+
+        mockMvc.perform(delete("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).with(csrf())
+                .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isNoContent());
+
+        assertTrue(listItemRepository.findById(userBListItem.getId()).orElseThrow().getDeleted());
     }
 
     @Test
     void testUserCanDeleteOwnListItem() throws Exception {
+
         mockMvc.perform(delete("/lists/" + userAList.getId() + "/items/" + userAListItem.getId()).with(csrf())
                 .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isNoContent());
 
-        assertTrue(listItemRepository.findById(userAListItem.getId()).isPresent(),
-                "Item should still exist in database (soft delete)");
-        assertTrue(listItemRepository.findById(userAListItem.getId()).get().getDeleted(),
-                "Item should be marked as deleted");
+        assertTrue(listItemRepository.findById(userAListItem.getId()).isPresent());
+
+        assertTrue(listItemRepository.findById(userAListItem.getId()).orElseThrow().getDeleted());
     }
 
     @Test
     void testUserCannotEditAnotherUsersListItem() throws Exception {
+
         ListItemUpdateRequestDTO maliciousUpdate = new ListItemUpdateRequestDTO(userBList.getId(), item.getId(), 99,
                 false, null);
 
@@ -276,12 +397,43 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
                 .content(objectMapper.writeValueAsString(maliciousUpdate))).andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.message").exists());
 
-        ListItem unchangedItem = listItemRepository.findById(userBListItem.getId()).orElseThrow();
-        assertEquals(1, unchangedItem.getQuantity(), "User B's item quantity should remain unchanged");
+        assertEquals(1, listItemRepository.findById(userBListItem.getId()).orElseThrow().getQuantity());
+    }
+
+    @Test
+    void testReadUserCannotEditSharedListItem() throws Exception {
+
+        grantPermission(userBList, userA, Permission.READ);
+
+        ListItemUpdateRequestDTO updateDTO = new ListItemUpdateRequestDTO(userBList.getId(), item.getId(), 99, false,
+                null);
+
+        mockMvc.perform(put("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).with(csrf())
+                .header("Authorization", "Bearer " + tokenUserA).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDTO))).andExpect(status().isForbidden());
+
+        assertEquals(1, listItemRepository.findById(userBListItem.getId()).orElseThrow().getQuantity());
+    }
+
+    @Test
+    void testWriteUserCanEditSharedListItem() throws Exception {
+
+        grantPermission(userBList, userA, Permission.WRITE);
+
+        ListItemUpdateRequestDTO updateDTO = new ListItemUpdateRequestDTO(userBList.getId(), item.getId(), 10, true,
+                null);
+
+        mockMvc.perform(put("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).with(csrf())
+                .header("Authorization", "Bearer " + tokenUserA).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateDTO))).andExpect(status().isOk())
+                .andExpect(jsonPath("$.quantity").value(10));
+
+        assertEquals(10, listItemRepository.findById(userBListItem.getId()).orElseThrow().getQuantity());
     }
 
     @Test
     void testUserCanEditOwnListItem() throws Exception {
+
         ListItemUpdateRequestDTO validUpdate = new ListItemUpdateRequestDTO(userAList.getId(), item.getId(), 10, true,
                 null);
 
@@ -290,23 +442,25 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
                 .content(objectMapper.writeValueAsString(validUpdate))).andExpect(status().isOk())
                 .andExpect(jsonPath("$.quantity").value(10));
 
-        ListItem updatedItem = listItemRepository.findById(userAListItem.getId()).orElseThrow();
-        assertEquals(10, updatedItem.getQuantity(), "User A's item quantity should be updated");
+        assertEquals(10, listItemRepository.findById(userAListItem.getId()).orElseThrow().getQuantity());
     }
 
     @Test
     void testUserCannotAccessItemsFromNonExistentList() throws Exception {
+
         mockMvc.perform(get("/lists/99999/items").header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void testUnauthorizedRequestIsRejected() throws Exception {
+
         mockMvc.perform(get("/lists/" + userAList.getId() + "/items")).andExpect(status().isForbidden());
     }
 
     @Test
     void testInvalidTokenIsRejected() throws Exception {
+
         mockMvc.perform(
                 get("/lists/" + userAList.getId() + "/items").header("Authorization", "Bearer invalid.token.here"))
                 .andExpect(status().isForbidden());
@@ -314,12 +468,14 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testGetListItemWithMismatchedListIdIsRejected() throws Exception {
+
         mockMvc.perform(get("/lists/" + userAList2.getId() + "/items/" + userAListItem.getId()).header("Authorization",
                 "Bearer " + tokenUserA)).andExpect(status().isNotFound()).andExpect(jsonPath("$.message").exists());
     }
 
     @Test
     void testPostListItemWithMismatchedPathListIdIsRejected() throws Exception {
+
         ListItemRequestDTO maliciousDTO = new ListItemRequestDTO(userAList2.getId(), item.getId(), 5, null);
 
         mockMvc.perform(post("/lists/" + userAList.getId() + "/items").with(csrf())
@@ -327,29 +483,21 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
                 .content(objectMapper.writeValueAsString(maliciousDTO))).andExpect(status().isBadRequest())
                 .andExpect(result -> assertTrue(result.getResolvedException() instanceof IllegalArgumentException));
 
-        Iterable<ListItem> userAList2Items = listItemRepository.findAll();
-        long userAList2ItemCount = 0;
-        for (ListItem li : userAList2Items) {
-            if (li.getShoppList().getId().equals(userAList2.getId())) {
-                userAList2ItemCount++;
-            }
-        }
-        assertEquals(0, userAList2ItemCount, "User A's second list should have no items");
+        assertEquals(0, countItemsForList(userAList2.getId()));
     }
 
     @Test
     void testDeleteListItemWithMismatchedListIdIsRejected() throws Exception {
+
         mockMvc.perform(delete("/lists/" + userAList2.getId() + "/items/" + userAListItem.getId()).with(csrf())
                 .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isNotFound());
 
-        assertTrue(listItemRepository.findById(userAListItem.getId()).isPresent(),
-                "User A's list item should still exist");
-        assertFalse(listItemRepository.findById(userAListItem.getId()).get().getDeleted(),
-                "Item should not be marked as deleted");
+        assertFalse(listItemRepository.findById(userAListItem.getId()).orElseThrow().getDeleted());
     }
 
     @Test
     void testUpdateListItemWithMismatchedPathListIdIsRejected() throws Exception {
+
         ListItemUpdateRequestDTO maliciousUpdate = new ListItemUpdateRequestDTO(userAList2.getId(), item.getId(), 99,
                 false, null);
 
@@ -358,7 +506,18 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
                 .content(objectMapper.writeValueAsString(maliciousUpdate))).andExpect(status().isBadRequest())
                 .andExpect(result -> assertTrue(result.getResolvedException() instanceof IllegalArgumentException));
 
-        ListItem unchangedItem = listItemRepository.findById(userAListItem.getId()).orElseThrow();
-        assertEquals(2, unchangedItem.getQuantity(), "User A's item quantity should remain unchanged");
+        assertEquals(2, listItemRepository.findById(userAListItem.getId()).orElseThrow().getQuantity());
+    }
+
+    private long countItemsForList(Long listId) {
+        long count = 0;
+
+        for (ListItem listItem : listItemRepository.findAll()) {
+            if (listItem.getShoppList().getId().equals(listId)) {
+                count++;
+            }
+        }
+
+        return count;
     }
 }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/list/controller/ListItemControllerSecurityIntegrationTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/list/controller/ListItemControllerSecurityIntegrationTest.java
@@ -10,7 +10,6 @@ import com.omatheusmesmo.shoppmate.list.dtos.ListItemRequestDTO;
 import com.omatheusmesmo.shoppmate.list.dtos.ListItemUpdateRequestDTO;
 import com.omatheusmesmo.shoppmate.list.dtos.ShoppingListRequestDTO;
 import com.omatheusmesmo.shoppmate.list.entity.ListItem;
-import com.omatheusmesmo.shoppmate.list.entity.ListPermission;
 import com.omatheusmesmo.shoppmate.list.entity.Permission;
 import com.omatheusmesmo.shoppmate.list.entity.ShoppingList;
 import com.omatheusmesmo.shoppmate.list.mapper.ListMapper;
@@ -20,7 +19,6 @@ import com.omatheusmesmo.shoppmate.list.repository.ShoppingListRepository;
 import com.omatheusmesmo.shoppmate.list.service.ListItemService;
 import com.omatheusmesmo.shoppmate.list.service.ShoppingListService;
 import com.omatheusmesmo.shoppmate.shared.testcontainers.AbstractIntegrationTest;
-import com.omatheusmesmo.shoppmate.shared.testutils.ListTestFactory;
 import com.omatheusmesmo.shoppmate.unit.entity.Unit;
 import com.omatheusmesmo.shoppmate.unit.repository.UnitRepository;
 import com.omatheusmesmo.shoppmate.user.entity.User;
@@ -35,9 +33,15 @@ import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static com.omatheusmesmo.shoppmate.shared.testutils.ListTestFactory.grantPermission;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -130,21 +134,15 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
         tokenUserB = jwtService.generateToken(userB);
 
         ShoppingListRequestDTO dtoA = new ShoppingListRequestDTO("User A's Shopping List");
-
         ShoppingList entityA = listMapper.toEntity(dtoA, userA);
-
         userAList = shoppingListService.saveList(entityA);
 
         ShoppingListRequestDTO dtoA2 = new ShoppingListRequestDTO("User A's Second Shopping List");
-
         ShoppingList entityA2 = listMapper.toEntity(dtoA2, userA);
-
         userAList2 = shoppingListService.saveList(entityA2);
 
         ShoppingListRequestDTO dtoB = new ShoppingListRequestDTO("User B's Shopping List");
-
         ShoppingList entityB = listMapper.toEntity(dtoB, userB);
-
         userBList = shoppingListService.saveList(entityB);
 
         Category category = new Category();
@@ -163,11 +161,9 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
         item = itemRepository.save(item);
 
         ListItemRequestDTO itemDTOA = new ListItemRequestDTO(userAList.getId(), item.getId(), 2, null);
-
         userAListItem = listItemService.addShoppItemList(itemDTOA, userA);
 
         ListItemRequestDTO itemDTOB = new ListItemRequestDTO(userBList.getId(), item.getId(), 1, null);
-
         userBListItem = listItemService.addShoppItemList(itemDTOB, userB);
     }
 
@@ -182,35 +178,21 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
         userRepository.deleteAll();
     }
 
-    private ListPermission grantPermission(ShoppingList shoppingList, User user, Permission permission) {
-
-        ListPermission listPermission = ListTestFactory.createValidListPermission(shoppingList);
-
-        listPermission.setShoppingList(shoppingList);
-        listPermission.setUser(user);
-        listPermission.setPermission(permission);
-
-        return listPermissionRepository.save(listPermission);
-    }
-
     @Test
     void testUserCannotGetAnotherUsersListItem() throws Exception {
-
         mockMvc.perform(get("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).header("Authorization",
                 "Bearer " + tokenUserA)).andExpect(status().isForbidden());
     }
 
     @Test
     void testUserCanGetOwnListItem() throws Exception {
-
         mockMvc.perform(get("/lists/" + userAList.getId() + "/items/" + userAListItem.getId()).header("Authorization",
                 "Bearer " + tokenUserA)).andExpect(status().isOk()).andExpect(jsonPath("$.quantity").value(2));
     }
 
     @Test
     void testReadUserCanGetSharedListItem() throws Exception {
-
-        grantPermission(userBList, userA, Permission.READ);
+        grantPermission(userBList, userA, Permission.READ, listPermissionRepository);
 
         mockMvc.perform(get("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).header("Authorization",
                 "Bearer " + tokenUserA)).andExpect(status().isOk()).andExpect(jsonPath("$.quantity").value(1));
@@ -218,8 +200,7 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testWriteUserCanGetSharedListItem() throws Exception {
-
-        grantPermission(userBList, userA, Permission.WRITE);
+        grantPermission(userBList, userA, Permission.WRITE, listPermissionRepository);
 
         mockMvc.perform(get("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).header("Authorization",
                 "Bearer " + tokenUserA)).andExpect(status().isOk()).andExpect(jsonPath("$.quantity").value(1));
@@ -227,14 +208,12 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testUserCannotGetAllItemsFromAnotherUsersList() throws Exception {
-
         mockMvc.perform(get("/lists/" + userBList.getId() + "/items").header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isForbidden()).andExpect(jsonPath("$.message").exists());
     }
 
     @Test
     void testUserCanGetAllItemsFromOwnList() throws Exception {
-
         mockMvc.perform(get("/lists/" + userAList.getId() + "/items").header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.size()").value(1))
                 .andExpect(jsonPath("$[0].quantity").value(2));
@@ -242,8 +221,7 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testReadUserCanGetAllItemsFromSharedList() throws Exception {
-
-        grantPermission(userBList, userA, Permission.READ);
+        grantPermission(userBList, userA, Permission.READ, listPermissionRepository);
 
         mockMvc.perform(get("/lists/" + userBList.getId() + "/items").header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.size()").value(1))
@@ -252,8 +230,7 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testWriteUserCanGetAllItemsFromSharedList() throws Exception {
-
-        grantPermission(userBList, userA, Permission.WRITE);
+        grantPermission(userBList, userA, Permission.WRITE, listPermissionRepository);
 
         mockMvc.perform(get("/lists/" + userBList.getId() + "/items").header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.size()").value(1))
@@ -262,7 +239,6 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testUserCannotAddItemToAnotherUsersList() throws Exception {
-
         ListItemRequestDTO maliciousDTO = new ListItemRequestDTO(userBList.getId(), item.getId(), 5, null);
 
         mockMvc.perform(post("/lists/" + userBList.getId() + "/items").with(csrf())
@@ -275,8 +251,7 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testReadUserCannotAddItemToSharedList() throws Exception {
-
-        grantPermission(userBList, userA, Permission.READ);
+        grantPermission(userBList, userA, Permission.READ, listPermissionRepository);
 
         ListItemRequestDTO requestDTO = new ListItemRequestDTO(userBList.getId(), item.getId(), 5, null);
 
@@ -289,8 +264,7 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testWriteUserCanAddItemToSharedList() throws Exception {
-
-        grantPermission(userBList, userA, Permission.WRITE);
+        grantPermission(userBList, userA, Permission.WRITE, listPermissionRepository);
 
         Category category = new Category();
         category.setName("Shared Bakery");
@@ -318,7 +292,6 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testUserCanAddItemToOwnList() throws Exception {
-
         Category category = new Category();
         category.setName("Bakery");
         category = categoryRepository.save(category);
@@ -345,7 +318,6 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testUserCannotDeleteAnotherUsersListItem() throws Exception {
-
         mockMvc.perform(delete("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).with(csrf())
                 .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.message").exists());
@@ -355,8 +327,7 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testReadUserCannotDeleteSharedListItem() throws Exception {
-
-        grantPermission(userBList, userA, Permission.READ);
+        grantPermission(userBList, userA, Permission.READ, listPermissionRepository);
 
         mockMvc.perform(delete("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).with(csrf())
                 .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isForbidden());
@@ -366,8 +337,7 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testWriteUserCanDeleteSharedListItem() throws Exception {
-
-        grantPermission(userBList, userA, Permission.WRITE);
+        grantPermission(userBList, userA, Permission.WRITE, listPermissionRepository);
 
         mockMvc.perform(delete("/lists/" + userBList.getId() + "/items/" + userBListItem.getId()).with(csrf())
                 .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isNoContent());
@@ -377,18 +347,15 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testUserCanDeleteOwnListItem() throws Exception {
-
         mockMvc.perform(delete("/lists/" + userAList.getId() + "/items/" + userAListItem.getId()).with(csrf())
                 .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isNoContent());
 
         assertTrue(listItemRepository.findById(userAListItem.getId()).isPresent());
-
         assertTrue(listItemRepository.findById(userAListItem.getId()).orElseThrow().getDeleted());
     }
 
     @Test
     void testUserCannotEditAnotherUsersListItem() throws Exception {
-
         ListItemUpdateRequestDTO maliciousUpdate = new ListItemUpdateRequestDTO(userBList.getId(), item.getId(), 99,
                 false, null);
 
@@ -402,8 +369,7 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testReadUserCannotEditSharedListItem() throws Exception {
-
-        grantPermission(userBList, userA, Permission.READ);
+        grantPermission(userBList, userA, Permission.READ, listPermissionRepository);
 
         ListItemUpdateRequestDTO updateDTO = new ListItemUpdateRequestDTO(userBList.getId(), item.getId(), 99, false,
                 null);
@@ -417,8 +383,7 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testWriteUserCanEditSharedListItem() throws Exception {
-
-        grantPermission(userBList, userA, Permission.WRITE);
+        grantPermission(userBList, userA, Permission.WRITE, listPermissionRepository);
 
         ListItemUpdateRequestDTO updateDTO = new ListItemUpdateRequestDTO(userBList.getId(), item.getId(), 10, true,
                 null);
@@ -433,7 +398,6 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testUserCanEditOwnListItem() throws Exception {
-
         ListItemUpdateRequestDTO validUpdate = new ListItemUpdateRequestDTO(userAList.getId(), item.getId(), 10, true,
                 null);
 
@@ -447,20 +411,17 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testUserCannotAccessItemsFromNonExistentList() throws Exception {
-
         mockMvc.perform(get("/lists/99999/items").header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void testUnauthorizedRequestIsRejected() throws Exception {
-
         mockMvc.perform(get("/lists/" + userAList.getId() + "/items")).andExpect(status().isForbidden());
     }
 
     @Test
     void testInvalidTokenIsRejected() throws Exception {
-
         mockMvc.perform(
                 get("/lists/" + userAList.getId() + "/items").header("Authorization", "Bearer invalid.token.here"))
                 .andExpect(status().isForbidden());
@@ -468,14 +429,12 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testGetListItemWithMismatchedListIdIsRejected() throws Exception {
-
         mockMvc.perform(get("/lists/" + userAList2.getId() + "/items/" + userAListItem.getId()).header("Authorization",
                 "Bearer " + tokenUserA)).andExpect(status().isNotFound()).andExpect(jsonPath("$.message").exists());
     }
 
     @Test
     void testPostListItemWithMismatchedPathListIdIsRejected() throws Exception {
-
         ListItemRequestDTO maliciousDTO = new ListItemRequestDTO(userAList2.getId(), item.getId(), 5, null);
 
         mockMvc.perform(post("/lists/" + userAList.getId() + "/items").with(csrf())
@@ -488,7 +447,6 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testDeleteListItemWithMismatchedListIdIsRejected() throws Exception {
-
         mockMvc.perform(delete("/lists/" + userAList2.getId() + "/items/" + userAListItem.getId()).with(csrf())
                 .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isNotFound());
 
@@ -497,7 +455,6 @@ class ListItemControllerSecurityIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     void testUpdateListItemWithMismatchedPathListIdIsRejected() throws Exception {
-
         ListItemUpdateRequestDTO maliciousUpdate = new ListItemUpdateRequestDTO(userAList2.getId(), item.getId(), 99,
                 false, null);
 

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/list/controller/ListPermissionControllerSecurityIntegrationTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/list/controller/ListPermissionControllerSecurityIntegrationTest.java
@@ -300,4 +300,93 @@ class ListPermissionControllerSecurityIntegrationTest extends AbstractIntegratio
         mockMvc.perform(get("/lists/" + ownerList.getId() + "/permissions").header("Authorization",
                 "Bearer invalid.token.here")).andExpect(status().isForbidden());
     }
+
+    @Test
+    void testUserWithWritePermissionCannotViewPermissions() throws Exception {
+        ListPermissionRequestDTO writePermissionDTO = new ListPermissionRequestDTO(ownerList.getId(), userA.getId(),
+                Permission.WRITE);
+
+        listPermissionService.addListPermission(writePermissionDTO, owner);
+
+        mockMvc.perform(
+                get("/lists/" + ownerList.getId() + "/permissions").header("Authorization", "Bearer " + tokenUserA))
+                .andExpect(status().isForbidden()).andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    void testUserWithWritePermissionCannotGrantPermission() throws Exception {
+        ListPermissionRequestDTO writePermissionDTO = new ListPermissionRequestDTO(ownerList.getId(), userA.getId(),
+                Permission.WRITE);
+
+        listPermissionService.addListPermission(writePermissionDTO, owner);
+
+        ListPermissionRequestDTO grantDTO = new ListPermissionRequestDTO(ownerList.getId(), userB.getId(),
+                Permission.READ);
+
+        mockMvc.perform(post("/lists/" + ownerList.getId() + "/permissions").with(csrf())
+                .header("Authorization", "Bearer " + tokenUserA).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(grantDTO))).andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").exists());
+
+        var permissions = listPermissionService.findAllPermissionsByListId(ownerList.getId(), owner);
+
+        assertEquals(1, permissions.size(), "WRITE user must not be able to grant another permission");
+    }
+
+    @Test
+    void testUserWithWritePermissionCannotUpdatePermission() throws Exception {
+        ListPermissionRequestDTO writePermissionDTO = new ListPermissionRequestDTO(ownerList.getId(), userA.getId(),
+                Permission.WRITE);
+
+        listPermissionService.addListPermission(writePermissionDTO, owner);
+
+        ListPermissionRequestDTO userBPermissionDTO = new ListPermissionRequestDTO(ownerList.getId(), userB.getId(),
+                Permission.READ);
+
+        listPermissionService.addListPermission(userBPermissionDTO, owner);
+
+        var permissions = listPermissionService.findAllPermissionsByListId(ownerList.getId(), owner);
+
+        Long userBPermissionId = permissions.stream()
+                .filter(permission -> permission.getUser().getId().equals(userB.getId())).findFirst().orElseThrow()
+                .getId();
+
+        ListPermissionRequestDTO maliciousUpdate = new ListPermissionRequestDTO(ownerList.getId(), userB.getId(),
+                Permission.WRITE);
+
+        mockMvc.perform(put("/lists/" + ownerList.getId() + "/permissions/" + userBPermissionId).with(csrf())
+                .header("Authorization", "Bearer " + tokenUserA).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(maliciousUpdate))).andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").exists());
+
+        var unchangedPermission = listPermissionRepository.findById(userBPermissionId).orElseThrow();
+
+        assertEquals(Permission.READ, unchangedPermission.getPermission());
+    }
+
+    @Test
+    void testUserWithWritePermissionCannotRevokePermission() throws Exception {
+        ListPermissionRequestDTO writePermissionDTO = new ListPermissionRequestDTO(ownerList.getId(), userA.getId(),
+                Permission.WRITE);
+
+        listPermissionService.addListPermission(writePermissionDTO, owner);
+
+        ListPermissionRequestDTO userBPermissionDTO = new ListPermissionRequestDTO(ownerList.getId(), userB.getId(),
+                Permission.READ);
+
+        listPermissionService.addListPermission(userBPermissionDTO, owner);
+
+        var permissions = listPermissionService.findAllPermissionsByListId(ownerList.getId(), owner);
+
+        Long userBPermissionId = permissions.stream()
+                .filter(permission -> permission.getUser().getId().equals(userB.getId())).findFirst().orElseThrow()
+                .getId();
+
+        mockMvc.perform(delete("/lists/" + ownerList.getId() + "/permissions/" + userBPermissionId).with(csrf())
+                .header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").exists());
+
+        assertTrue(listPermissionRepository.findById(userBPermissionId).isPresent(),
+                "WRITE user must not be able to revoke permissions");
+    }
 }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/list/controller/ShoppingListControllerSecurityIntegrationTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/list/controller/ShoppingListControllerSecurityIntegrationTest.java
@@ -5,7 +5,6 @@ import com.omatheusmesmo.shoppmate.auth.service.JwtService;
 import com.omatheusmesmo.shoppmate.list.dtos.ShoppingListRequestDTO;
 import com.omatheusmesmo.shoppmate.list.dtos.ShoppingListResponseDTO;
 import com.omatheusmesmo.shoppmate.list.dtos.ShoppingListUpdateRequestDTO;
-import com.omatheusmesmo.shoppmate.list.entity.ListPermission;
 import com.omatheusmesmo.shoppmate.list.entity.Permission;
 import com.omatheusmesmo.shoppmate.list.entity.ShoppingList;
 import com.omatheusmesmo.shoppmate.list.mapper.ListMapper;
@@ -13,7 +12,6 @@ import com.omatheusmesmo.shoppmate.list.repository.ListPermissionRepository;
 import com.omatheusmesmo.shoppmate.list.repository.ShoppingListRepository;
 import com.omatheusmesmo.shoppmate.list.service.ShoppingListService;
 import com.omatheusmesmo.shoppmate.shared.testcontainers.AbstractIntegrationTest;
-import com.omatheusmesmo.shoppmate.shared.testutils.ListTestFactory;
 import com.omatheusmesmo.shoppmate.user.entity.User;
 import com.omatheusmesmo.shoppmate.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -27,10 +25,18 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static com.omatheusmesmo.shoppmate.shared.testutils.ListTestFactory.grantPermission;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -96,15 +102,11 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
         tokenUserB = jwtService.generateToken(userB);
 
         ShoppingListRequestDTO dtoA = new ShoppingListRequestDTO("User A's Shopping List");
-
         ShoppingList entityA = listMapper.toEntity(dtoA, userA);
-
         userAList = shoppingListService.saveList(entityA);
 
         ShoppingListRequestDTO dtoB = new ShoppingListRequestDTO("User B's Shopping List");
-
         ShoppingList entityB = listMapper.toEntity(dtoB, userB);
-
         userBList = shoppingListService.saveList(entityB);
     }
 
@@ -115,35 +117,21 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
         userRepository.deleteAll();
     }
 
-    private ListPermission grantPermission(ShoppingList shoppingList, User user, Permission permission) {
-
-        ListPermission listPermission = ListTestFactory.createValidListPermission(shoppingList);
-
-        listPermission.setShoppingList(shoppingList);
-        listPermission.setUser(user);
-        listPermission.setPermission(permission);
-
-        return listPermissionRepository.save(listPermission);
-    }
-
     @Test
     void testUserCannotGetAnotherUsersShoppingList() throws Exception {
-
         mockMvc.perform(get("/lists/" + userBList.getId()).header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     void testUserCanGetOwnShoppingList() throws Exception {
-
         mockMvc.perform(get("/lists/" + userAList.getId()).header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.listName").value("User A's Shopping List"));
     }
 
     @Test
     void testUserWithReadPermissionCanGetSharedShoppingList() throws Exception {
-
-        grantPermission(userBList, userA, Permission.READ);
+        grantPermission(userBList, userA, Permission.READ, listPermissionRepository);
 
         mockMvc.perform(get("/lists/" + userBList.getId()).header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.listName").value("User B's Shopping List"));
@@ -151,8 +139,7 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserWithWritePermissionCanGetSharedShoppingList() throws Exception {
-
-        grantPermission(userBList, userA, Permission.WRITE);
+        grantPermission(userBList, userA, Permission.WRITE, listPermissionRepository);
 
         mockMvc.perform(get("/lists/" + userBList.getId()).header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.listName").value("User B's Shopping List"));
@@ -160,7 +147,6 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserCannotDeleteAnotherUsersShoppingList() throws Exception {
-
         mockMvc.perform(
                 delete("/lists/" + userBList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isForbidden());
@@ -170,8 +156,7 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserWithReadPermissionCannotDeleteSharedShoppingList() throws Exception {
-
-        grantPermission(userBList, userA, Permission.READ);
+        grantPermission(userBList, userA, Permission.READ, listPermissionRepository);
 
         mockMvc.perform(
                 delete("/lists/" + userBList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA))
@@ -182,8 +167,7 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserWithWritePermissionCannotDeleteSharedShoppingList() throws Exception {
-
-        grantPermission(userBList, userA, Permission.WRITE);
+        grantPermission(userBList, userA, Permission.WRITE, listPermissionRepository);
 
         mockMvc.perform(
                 delete("/lists/" + userBList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA))
@@ -194,7 +178,6 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserCanDeleteOwnShoppingList() throws Exception {
-
         mockMvc.perform(
                 delete("/lists/" + userAList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isNoContent());
@@ -204,7 +187,6 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserCannotEditAnotherUsersShoppingList() throws Exception {
-
         ShoppingListUpdateRequestDTO updateDTO = new ShoppingListUpdateRequestDTO("Malicious Update");
 
         mockMvc.perform(put("/lists/" + userBList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA)
@@ -218,8 +200,7 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserWithReadPermissionCannotEditSharedShoppingList() throws Exception {
-
-        grantPermission(userBList, userA, Permission.READ);
+        grantPermission(userBList, userA, Permission.READ, listPermissionRepository);
 
         ShoppingListUpdateRequestDTO updateDTO = new ShoppingListUpdateRequestDTO("Unauthorized Update");
 
@@ -234,8 +215,7 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserWithWritePermissionCannotEditSharedListMetadata() throws Exception {
-
-        grantPermission(userBList, userA, Permission.WRITE);
+        grantPermission(userBList, userA, Permission.WRITE, listPermissionRepository);
 
         ShoppingListUpdateRequestDTO updateDTO = new ShoppingListUpdateRequestDTO("Unauthorized Metadata Update");
 
@@ -250,7 +230,6 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserCanEditOwnShoppingList() throws Exception {
-
         ShoppingListUpdateRequestDTO updateDTO = new ShoppingListUpdateRequestDTO("Updated List Name");
 
         mockMvc.perform(put("/lists/" + userAList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA)
@@ -264,7 +243,6 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserCannotCreateListWithDifferentOwnerId() throws Exception {
-
         ShoppingListRequestDTO createDTO = new ShoppingListRequestDTO("New List");
 
         MvcResult result = mockMvc
@@ -285,17 +263,14 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testGetAllListsOnlyReturnsUsersOwnLists() throws Exception {
-
         ShoppingListRequestDTO dtoA2 = new ShoppingListRequestDTO("User A's Second List");
 
         ShoppingList entityA2 = listMapper.toEntity(dtoA2, userA);
-
         shoppingListService.saveList(entityA2);
 
         ShoppingListRequestDTO dtoB2 = new ShoppingListRequestDTO("User B's Second List");
 
         ShoppingList entityB2 = listMapper.toEntity(dtoB2, userB);
-
         shoppingListService.saveList(entityB2);
 
         mockMvc.perform(get("/lists").header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isOk())
@@ -308,20 +283,17 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserCannotAccessNonExistentList() throws Exception {
-
         mockMvc.perform(get("/lists/99999").header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void testUnauthorizedRequestIsRejected() throws Exception {
-
         mockMvc.perform(get("/lists")).andExpect(status().isForbidden());
     }
 
     @Test
     void testInvalidTokenIsRejected() throws Exception {
-
         mockMvc.perform(get("/lists").header("Authorization", "Bearer invalid.token.here"))
                 .andExpect(status().isForbidden());
     }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/list/controller/ShoppingListControllerSecurityIntegrationTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/list/controller/ShoppingListControllerSecurityIntegrationTest.java
@@ -5,12 +5,15 @@ import com.omatheusmesmo.shoppmate.auth.service.JwtService;
 import com.omatheusmesmo.shoppmate.list.dtos.ShoppingListRequestDTO;
 import com.omatheusmesmo.shoppmate.list.dtos.ShoppingListResponseDTO;
 import com.omatheusmesmo.shoppmate.list.dtos.ShoppingListUpdateRequestDTO;
+import com.omatheusmesmo.shoppmate.list.entity.ListPermission;
+import com.omatheusmesmo.shoppmate.list.entity.Permission;
 import com.omatheusmesmo.shoppmate.list.entity.ShoppingList;
 import com.omatheusmesmo.shoppmate.list.mapper.ListMapper;
 import com.omatheusmesmo.shoppmate.list.repository.ListPermissionRepository;
 import com.omatheusmesmo.shoppmate.list.repository.ShoppingListRepository;
 import com.omatheusmesmo.shoppmate.list.service.ShoppingListService;
 import com.omatheusmesmo.shoppmate.shared.testcontainers.AbstractIntegrationTest;
+import com.omatheusmesmo.shoppmate.shared.testutils.ListTestFactory;
 import com.omatheusmesmo.shoppmate.user.entity.User;
 import com.omatheusmesmo.shoppmate.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -62,6 +65,7 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     private User userA;
     private User userB;
+
     private ShoppingList userAList;
     private ShoppingList userBList;
 
@@ -92,11 +96,15 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
         tokenUserB = jwtService.generateToken(userB);
 
         ShoppingListRequestDTO dtoA = new ShoppingListRequestDTO("User A's Shopping List");
+
         ShoppingList entityA = listMapper.toEntity(dtoA, userA);
+
         userAList = shoppingListService.saveList(entityA);
 
         ShoppingListRequestDTO dtoB = new ShoppingListRequestDTO("User B's Shopping List");
+
         ShoppingList entityB = listMapper.toEntity(dtoB, userB);
+
         userBList = shoppingListService.saveList(entityB);
     }
 
@@ -107,20 +115,76 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
         userRepository.deleteAll();
     }
 
+    private ListPermission grantPermission(ShoppingList shoppingList, User user, Permission permission) {
+
+        ListPermission listPermission = ListTestFactory.createValidListPermission(shoppingList);
+
+        listPermission.setShoppingList(shoppingList);
+        listPermission.setUser(user);
+        listPermission.setPermission(permission);
+
+        return listPermissionRepository.save(listPermission);
+    }
+
     @Test
     void testUserCannotGetAnotherUsersShoppingList() throws Exception {
+
         mockMvc.perform(get("/lists/" + userBList.getId()).header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     void testUserCanGetOwnShoppingList() throws Exception {
+
         mockMvc.perform(get("/lists/" + userAList.getId()).header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.listName").value("User A's Shopping List"));
     }
 
     @Test
+    void testUserWithReadPermissionCanGetSharedShoppingList() throws Exception {
+
+        grantPermission(userBList, userA, Permission.READ);
+
+        mockMvc.perform(get("/lists/" + userBList.getId()).header("Authorization", "Bearer " + tokenUserA))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.listName").value("User B's Shopping List"));
+    }
+
+    @Test
+    void testUserWithWritePermissionCanGetSharedShoppingList() throws Exception {
+
+        grantPermission(userBList, userA, Permission.WRITE);
+
+        mockMvc.perform(get("/lists/" + userBList.getId()).header("Authorization", "Bearer " + tokenUserA))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.listName").value("User B's Shopping List"));
+    }
+
+    @Test
     void testUserCannotDeleteAnotherUsersShoppingList() throws Exception {
+
+        mockMvc.perform(
+                delete("/lists/" + userBList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA))
+                .andExpect(status().isForbidden());
+
+        assertTrue(shoppingListRepository.findById(userBList.getId()).isPresent());
+    }
+
+    @Test
+    void testUserWithReadPermissionCannotDeleteSharedShoppingList() throws Exception {
+
+        grantPermission(userBList, userA, Permission.READ);
+
+        mockMvc.perform(
+                delete("/lists/" + userBList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA))
+                .andExpect(status().isForbidden());
+
+        assertTrue(shoppingListRepository.findById(userBList.getId()).isPresent());
+    }
+
+    @Test
+    void testUserWithWritePermissionCannotDeleteSharedShoppingList() throws Exception {
+
+        grantPermission(userBList, userA, Permission.WRITE);
+
         mockMvc.perform(
                 delete("/lists/" + userBList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isForbidden());
@@ -130,6 +194,7 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserCanDeleteOwnShoppingList() throws Exception {
+
         mockMvc.perform(
                 delete("/lists/" + userAList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isNoContent());
@@ -139,6 +204,7 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserCannotEditAnotherUsersShoppingList() throws Exception {
+
         ShoppingListUpdateRequestDTO updateDTO = new ShoppingListUpdateRequestDTO("Malicious Update");
 
         mockMvc.perform(put("/lists/" + userBList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA)
@@ -146,11 +212,45 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
                 .andExpect(status().isForbidden());
 
         ShoppingList unchangedList = shoppingListRepository.findById(userBList.getId()).orElseThrow();
+
+        assertEquals("User B's Shopping List", unchangedList.getName());
+    }
+
+    @Test
+    void testUserWithReadPermissionCannotEditSharedShoppingList() throws Exception {
+
+        grantPermission(userBList, userA, Permission.READ);
+
+        ShoppingListUpdateRequestDTO updateDTO = new ShoppingListUpdateRequestDTO("Unauthorized Update");
+
+        mockMvc.perform(put("/lists/" + userBList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA)
+                .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateDTO)))
+                .andExpect(status().isForbidden());
+
+        ShoppingList unchangedList = shoppingListRepository.findById(userBList.getId()).orElseThrow();
+
+        assertEquals("User B's Shopping List", unchangedList.getName());
+    }
+
+    @Test
+    void testUserWithWritePermissionCannotEditSharedListMetadata() throws Exception {
+
+        grantPermission(userBList, userA, Permission.WRITE);
+
+        ShoppingListUpdateRequestDTO updateDTO = new ShoppingListUpdateRequestDTO("Unauthorized Metadata Update");
+
+        mockMvc.perform(put("/lists/" + userBList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA)
+                .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateDTO)))
+                .andExpect(status().isForbidden());
+
+        ShoppingList unchangedList = shoppingListRepository.findById(userBList.getId()).orElseThrow();
+
         assertEquals("User B's Shopping List", unchangedList.getName());
     }
 
     @Test
     void testUserCanEditOwnShoppingList() throws Exception {
+
         ShoppingListUpdateRequestDTO updateDTO = new ShoppingListUpdateRequestDTO("Updated List Name");
 
         mockMvc.perform(put("/lists/" + userAList.getId()).with(csrf()).header("Authorization", "Bearer " + tokenUserA)
@@ -158,11 +258,13 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
                 .andExpect(status().isOk()).andExpect(jsonPath("$.listName").value("Updated List Name"));
 
         ShoppingList updatedList = shoppingListRepository.findById(userAList.getId()).orElseThrow();
+
         assertEquals("Updated List Name", updatedList.getName());
     }
 
     @Test
     void testUserCannotCreateListWithDifferentOwnerId() throws Exception {
+
         ShoppingListRequestDTO createDTO = new ShoppingListRequestDTO("New List");
 
         MvcResult result = mockMvc
@@ -171,22 +273,29 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
                 .andExpect(status().isCreated()).andReturn();
 
         String response = result.getResponse().getContentAsString();
+
         ShoppingListResponseDTO responseDTO = objectMapper.readValue(response, ShoppingListResponseDTO.class);
 
         ShoppingList createdList = shoppingListRepository.findById(responseDTO.idList()).orElseThrow();
-        assertEquals(userA.getId(), createdList.getOwner().getId(),
-                "List should be owned by authenticated user (User A), not a different user");
-        assertNotEquals(userB.getId(), createdList.getOwner().getId(), "List should NOT be owned by User B");
+
+        assertEquals(userA.getId(), createdList.getOwner().getId(), "List should be owned by authenticated user");
+
+        assertNotEquals(userB.getId(), createdList.getOwner().getId(), "List should not be owned by User B");
     }
 
     @Test
     void testGetAllListsOnlyReturnsUsersOwnLists() throws Exception {
+
         ShoppingListRequestDTO dtoA2 = new ShoppingListRequestDTO("User A's Second List");
+
         ShoppingList entityA2 = listMapper.toEntity(dtoA2, userA);
+
         shoppingListService.saveList(entityA2);
 
         ShoppingListRequestDTO dtoB2 = new ShoppingListRequestDTO("User B's Second List");
+
         ShoppingList entityB2 = listMapper.toEntity(dtoB2, userB);
+
         shoppingListService.saveList(entityB2);
 
         mockMvc.perform(get("/lists").header("Authorization", "Bearer " + tokenUserA)).andExpect(status().isOk())
@@ -199,17 +308,20 @@ class ShoppingListControllerSecurityIntegrationTest extends AbstractIntegrationT
 
     @Test
     void testUserCannotAccessNonExistentList() throws Exception {
+
         mockMvc.perform(get("/lists/99999").header("Authorization", "Bearer " + tokenUserA))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void testUnauthorizedRequestIsRejected() throws Exception {
+
         mockMvc.perform(get("/lists")).andExpect(status().isForbidden());
     }
 
     @Test
     void testInvalidTokenIsRejected() throws Exception {
+
         mockMvc.perform(get("/lists").header("Authorization", "Bearer invalid.token.here"))
                 .andExpect(status().isForbidden());
     }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/list/service/ListItemServiceTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/list/service/ListItemServiceTest.java
@@ -28,12 +28,16 @@ class ListItemServiceTest {
 
     @Mock
     private ListItemRepository listItemRepository;
+
     @Mock
     private ShoppingListService shoppingListService;
+
     @Mock
     private ItemService itemService;
+
     @Mock
     private AuditService auditService;
+
     @Mock
     private ListItemMapper listItemMapper;
 
@@ -49,158 +53,182 @@ class ListItemServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+
         shoppingList = ListTestFactory.createValidShoppingList();
         user = shoppingList.getOwner();
         listItem = ListTestFactory.createValidListItem(shoppingList);
         item = listItem.getItem();
+
         listItemRequestDTO = ListTestFactory.createValidListItemRequestDTO(shoppingList.getId(), item.getId());
     }
 
     @Test
     void addShoppItemList_ValidDTO_ReturnsSavedListItem() {
-        // Arrange
         when(itemService.findById(item.getId())).thenReturn(item);
-        when(shoppingListService.findListById(shoppingList.getId())).thenReturn(shoppingList);
-        doNothing().when(shoppingListService).verifyOwnership(shoppingList.getId(), user);
+
+        when(shoppingListService.findAndVerifyWriteAccess(shoppingList.getId(), user)).thenReturn(shoppingList);
+
         when(listItemMapper.toEntity(listItemRequestDTO, item, shoppingList)).thenReturn(listItem);
+
         when(listItemRepository.save(listItem)).thenReturn(listItem);
 
-        // Act
         ListItem savedItem = service.addShoppItemList(listItemRequestDTO, user);
 
-        // Assert
         assertNotNull(savedItem);
         assertEquals(listItem, savedItem);
-        verify(itemService, times(1)).isItemValid(item);
-        verify(shoppingListService, times(1)).isListValid(shoppingList);
-        verify(shoppingListService, times(1)).verifyOwnership(shoppingList.getId(), user);
-        verify(auditService, times(1)).setAuditData(listItem, true);
-        verify(listItemRepository, times(1)).save(listItem);
+
+        verify(itemService).findById(item.getId());
+
+        verify(shoppingListService).findAndVerifyWriteAccess(shoppingList.getId(), user);
+
+        verify(itemService).isItemValid(item);
+        verify(shoppingListService).isListValid(shoppingList);
+        verify(auditService).setAuditData(listItem, true);
+        verify(listItemRepository).save(listItem);
     }
 
     @Test
     void isListItemValid_ValidListItem_NoExceptionThrown() {
-        // Act & Assert
         assertDoesNotThrow(() -> service.isListItemValid(listItem));
-        verify(itemService, times(1)).isItemValid(item);
-        verify(shoppingListService, times(1)).isListValid(shoppingList);
+
+        verify(itemService).isItemValid(item);
+        verify(shoppingListService).isListValid(shoppingList);
     }
 
     @Test
     void isListItemValid_NullQuantity_ThrowsIllegalArgumentException() {
-        // Arrange
         listItem.setQuantity(null);
 
-        // Act & Assert
         assertThrows(IllegalArgumentException.class, () -> service.isListItemValid(listItem));
     }
 
     @Test
-    void findListItemById_ExistingId_ReturnsListItem() {
-        // Arrange
-        doNothing().when(shoppingListService).verifyOwnership(shoppingList.getId(), user);
+    void findListItemByIdForRead_ExistingId_ReturnsListItem() {
+        when(shoppingListService.findAndVerifyReadAccess(shoppingList.getId(), user)).thenReturn(shoppingList);
+
         when(listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(listItem.getId(),
                 shoppingList.getId())).thenReturn(Optional.of(listItem));
 
-        // Act
-        ListItem result = service.findListItemById(shoppingList.getId(), listItem.getId(), user);
+        ListItem result = service.findListItemByIdForRead(shoppingList.getId(), listItem.getId(), user);
 
-        // Assert
         assertNotNull(result);
         assertEquals(listItem, result);
-        verify(shoppingListService, times(1)).verifyOwnership(shoppingList.getId(), user);
-        verify(listItemRepository, times(1)).findByIdAndShoppListIdAndDeletedFalseFetchShoppList(listItem.getId(),
+
+        verify(shoppingListService).findAndVerifyReadAccess(shoppingList.getId(), user);
+
+        verify(listItemRepository).findByIdAndShoppListIdAndDeletedFalseFetchShoppList(listItem.getId(),
                 shoppingList.getId());
     }
 
     @Test
-    void findListItemById_NonExistingId_ThrowsNoSuchElementException() {
-        // Arrange
-        doNothing().when(shoppingListService).verifyOwnership(shoppingList.getId(), user);
-        when(listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(anyLong(), anyLong()))
+    void findListItemByIdForWrite_ExistingId_ReturnsListItem() {
+        when(shoppingListService.findAndVerifyWriteAccess(shoppingList.getId(), user)).thenReturn(shoppingList);
+
+        when(listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(listItem.getId(),
+                shoppingList.getId())).thenReturn(Optional.of(listItem));
+
+        ListItem result = service.findListItemByIdForWrite(shoppingList.getId(), listItem.getId(), user);
+
+        assertNotNull(result);
+        assertEquals(listItem, result);
+
+        verify(shoppingListService).findAndVerifyWriteAccess(shoppingList.getId(), user);
+
+        verify(listItemRepository).findByIdAndShoppListIdAndDeletedFalseFetchShoppList(listItem.getId(),
+                shoppingList.getId());
+    }
+
+    @Test
+    void findListItemByIdForWrite_NonExistingId_ThrowsNoSuchElementException() {
+        when(shoppingListService.findAndVerifyWriteAccess(shoppingList.getId(), user)).thenReturn(shoppingList);
+
+        when(listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(999L, shoppingList.getId()))
                 .thenReturn(Optional.empty());
 
-        // Act & Assert
-        assertThrows(NoSuchElementException.class, () -> service.findListItemById(shoppingList.getId(), 999L, user));
+        assertThrows(NoSuchElementException.class,
+                () -> service.findListItemByIdForWrite(shoppingList.getId(), 999L, user));
+
         verify(listItemRepository, never()).save(any());
     }
 
     @Test
     void removeList_ExistingId_SoftDeletesListItem() {
-        // Arrange
-        doNothing().when(shoppingListService).verifyOwnership(shoppingList.getId(), user);
+        when(shoppingListService.findAndVerifyWriteAccess(shoppingList.getId(), user)).thenReturn(shoppingList);
+
         when(listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(listItem.getId(),
                 shoppingList.getId())).thenReturn(Optional.of(listItem));
 
-        // Act
         assertDoesNotThrow(() -> service.removeList(shoppingList.getId(), listItem.getId(), user));
 
-        // Assert
-        verify(auditService, times(1)).softDelete(listItem);
-        verify(listItemRepository, times(1)).save(listItem);
+        verify(shoppingListService).findAndVerifyWriteAccess(shoppingList.getId(), user);
+
+        verify(auditService).softDelete(listItem);
+        verify(listItemRepository).save(listItem);
     }
 
     @Test
     void removeList_NonExistingId_ThrowsNoSuchElementException() {
-        // Arrange
-        doNothing().when(shoppingListService).verifyOwnership(shoppingList.getId(), user);
-        when(listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(anyLong(), anyLong()))
+        when(shoppingListService.findAndVerifyWriteAccess(shoppingList.getId(), user)).thenReturn(shoppingList);
+
+        when(listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(999L, shoppingList.getId()))
                 .thenReturn(Optional.empty());
 
-        // Act & Assert
         assertThrows(NoSuchElementException.class, () -> service.removeList(shoppingList.getId(), 999L, user));
+
         verify(auditService, never()).softDelete(any());
         verify(listItemRepository, never()).save(any());
     }
 
     @Test
     void editList_ValidUpdate_ReturnsUpdatedListItem() {
-        // Arrange
         ListItemUpdateRequestDTO updateDTO = ListTestFactory.createValidListItemUpdateRequestDTO(shoppingList.getId(),
                 item.getId());
-        doNothing().when(shoppingListService).verifyOwnership(shoppingList.getId(), user);
+
+        when(shoppingListService.findAndVerifyWriteAccess(shoppingList.getId(), user)).thenReturn(shoppingList);
+
         when(listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(listItem.getId(),
                 shoppingList.getId())).thenReturn(Optional.of(listItem));
 
-        // Act
         ListItem result = service.editList(shoppingList.getId(), listItem.getId(), updateDTO, user);
 
-        // Assert
         assertNotNull(result);
         assertEquals(updateDTO.quantity(), result.getQuantity());
         assertEquals(updateDTO.purchased(), result.getPurchased());
         assertEquals(updateDTO.unitPrice(), result.getUnitPrice());
-        verify(auditService, times(1)).setAuditData(listItem, false);
-        verify(listItemRepository, times(1)).save(listItem);
+
+        verify(shoppingListService).findAndVerifyWriteAccess(shoppingList.getId(), user);
+
+        verify(auditService).setAuditData(listItem, false);
+        verify(listItemRepository).save(listItem);
     }
 
     @Test
     void editList_NonExistingId_ThrowsNoSuchElementException() {
-        // Arrange
         ListItemUpdateRequestDTO updateDTO = ListTestFactory.createValidListItemUpdateRequestDTO(shoppingList.getId(),
                 item.getId());
-        doNothing().when(shoppingListService).verifyOwnership(shoppingList.getId(), user);
-        when(listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(anyLong(), anyLong()))
+
+        when(shoppingListService.findAndVerifyWriteAccess(shoppingList.getId(), user)).thenReturn(shoppingList);
+
+        when(listItemRepository.findByIdAndShoppListIdAndDeletedFalseFetchShoppList(999L, shoppingList.getId()))
                 .thenReturn(Optional.empty());
 
-        // Act & Assert
         assertThrows(NoSuchElementException.class, () -> service.editList(shoppingList.getId(), 999L, updateDTO, user));
     }
 
     @Test
     void findAll_ExistingListId_ReturnsItems() {
-        // Arrange
-        doNothing().when(shoppingListService).verifyOwnership(shoppingList.getId(), user);
+        when(shoppingListService.findAndVerifyReadAccess(shoppingList.getId(), user)).thenReturn(shoppingList);
+
         when(listItemRepository.findByShoppListIdAndDeletedFalse(shoppingList.getId())).thenReturn(List.of(listItem));
 
-        // Act
         List<ListItem> result = service.findAll(shoppingList.getId(), user);
 
-        // Assert
         assertNotNull(result);
         assertEquals(1, result.size());
         assertEquals(listItem, result.get(0));
-        verify(shoppingListService, times(1)).verifyOwnership(shoppingList.getId(), user);
-        verify(listItemRepository, times(1)).findByShoppListIdAndDeletedFalse(shoppingList.getId());
+
+        verify(shoppingListService).findAndVerifyReadAccess(shoppingList.getId(), user);
+
+        verify(listItemRepository).findByShoppListIdAndDeletedFalse(shoppingList.getId());
     }
 }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/list/service/ListPermissionServiceTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/list/service/ListPermissionServiceTest.java
@@ -50,146 +50,232 @@ class ListPermissionServiceTest {
     private ShoppingList shoppingList;
     private User owner;
     private User targetUser;
+    private User nonOwner;
     private ListPermission listPermission;
 
     @BeforeEach
     void setUp() {
         shoppingList = ListTestFactory.createValidShoppingList();
         owner = shoppingList.getOwner();
+
         listPermission = ListTestFactory.createValidListPermission(shoppingList);
+
         targetUser = listPermission.getUser();
+
+        nonOwner = new User();
+        nonOwner.setId(owner.getId() + 1000);
     }
 
     @Test
-    void addListPermission_ValidDTO_ReturnsSavedPermission() {
-        // Arrange
+    void addListPermission_Owner_ReturnsSavedPermission() {
         ListPermissionRequestDTO requestDTO = ListTestFactory.createValidListPermissionRequestDTO(shoppingList.getId(),
                 targetUser.getId());
-        when(shoppingListService.findListById(shoppingList.getId())).thenReturn(shoppingList);
-        when(userService.findUserById(targetUser.getId())).thenReturn(targetUser);
-        when(listPermissionMapper.toEntity(requestDTO, shoppingList, targetUser)).thenReturn(listPermission);
-        when(listPermissionRepository.save(any(ListPermission.class))).thenReturn(listPermission);
 
-        // Act
+        when(shoppingListService.findAndVerifyOwnership(shoppingList.getId(), owner)).thenReturn(shoppingList);
+
+        when(userService.findUserById(targetUser.getId())).thenReturn(targetUser);
+
+        when(listPermissionMapper.toEntity(requestDTO, shoppingList, targetUser)).thenReturn(listPermission);
+
+        when(listPermissionRepository.save(listPermission)).thenReturn(listPermission);
+
         ListPermission result = listPermissionService.addListPermission(requestDTO, owner);
 
-        // Assert
         assertNotNull(result);
         assertEquals(listPermission, result);
-        verify(auditService, times(1)).setAuditData(listPermission, true);
-        verify(listPermissionRepository, times(1)).save(listPermission);
+
+        verify(shoppingListService).findAndVerifyOwnership(shoppingList.getId(), owner);
+
+        verify(userService).findUserById(targetUser.getId());
+
+        verify(auditService).setAuditData(listPermission, true);
+
+        verify(listPermissionRepository).save(listPermission);
     }
 
     @Test
-    void addListPermission_RequesterNotOwner_ThrowsResourceOwnershipException() {
-        // Arrange
+    void addListPermission_NonOwner_ThrowsResourceOwnershipException() {
         ListPermissionRequestDTO requestDTO = ListTestFactory.createValidListPermissionRequestDTO(shoppingList.getId(),
                 targetUser.getId());
-        User nonOwner = new User();
-        nonOwner.setId(owner.getId() + 1000);
-        when(shoppingListService.findListById(shoppingList.getId())).thenReturn(shoppingList);
 
-        // Act & Assert
-        ResourceOwnershipException exception = assertThrows(ResourceOwnershipException.class,
+        when(shoppingListService.findAndVerifyOwnership(shoppingList.getId(), nonOwner))
+                .thenThrow(new ResourceOwnershipException("Only the list owner can manage permissions"));
+
+        assertThrows(ResourceOwnershipException.class,
                 () -> listPermissionService.addListPermission(requestDTO, nonOwner));
-        assertTrue(exception.getMessage().contains("Only the list owner can grant permissions"));
+
+        verify(userService, never()).findUserById(anyLong());
+        verify(listPermissionMapper, never()).toEntity(any(), any(), any());
+
         verify(listPermissionRepository, never()).save(any());
     }
 
     @Test
-    void editList_ExistingId_ReturnsUpdatedPermission() {
-        // Arrange
+    void editList_Owner_ReturnsUpdatedPermission() {
         ListPermissionUpdateRequestDTO updateDTO = ListTestFactory.createValidListPermissionUpdateRequestDTO();
+
         when(listPermissionRepository.findByIdAndDeletedFalse(listPermission.getId()))
                 .thenReturn(Optional.of(listPermission));
-        when(listPermissionRepository.save(any(ListPermission.class))).thenReturn(listPermission);
 
-        // Act
+        when(shoppingListService.findAndVerifyOwnership(shoppingList.getId(), owner)).thenReturn(shoppingList);
+
+        when(listPermissionRepository.save(listPermission)).thenReturn(listPermission);
+
         ListPermission result = listPermissionService.editList(listPermission.getId(), updateDTO, owner);
 
-        // Assert
         assertNotNull(result);
         assertEquals(updateDTO.permission(), result.getPermission());
-        verify(auditService, times(1)).setAuditData(listPermission, false);
-        verify(listPermissionRepository, times(1)).save(listPermission);
+
+        verify(shoppingListService).findAndVerifyOwnership(shoppingList.getId(), owner);
+
+        verify(auditService).setAuditData(listPermission, false);
+
+        verify(listPermissionRepository).save(listPermission);
+    }
+
+    @Test
+    void editList_NonOwner_ThrowsResourceOwnershipException() {
+        ListPermissionUpdateRequestDTO updateDTO = ListTestFactory.createValidListPermissionUpdateRequestDTO();
+
+        when(listPermissionRepository.findByIdAndDeletedFalse(listPermission.getId()))
+                .thenReturn(Optional.of(listPermission));
+
+        when(shoppingListService.findAndVerifyOwnership(shoppingList.getId(), nonOwner))
+                .thenThrow(new ResourceOwnershipException("Only the list owner can manage permissions"));
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> listPermissionService.editList(listPermission.getId(), updateDTO, nonOwner));
+
+        verify(auditService, never()).setAuditData(any(), anyBoolean());
+
+        verify(listPermissionRepository, never()).save(any());
     }
 
     @Test
     void editList_NonExistingId_ThrowsNoSuchElementException() {
-        // Arrange
         Long nonExistingId = listPermission.getId() + 1000;
+
         ListPermissionUpdateRequestDTO updateDTO = ListTestFactory.createValidListPermissionUpdateRequestDTO();
+
         when(listPermissionRepository.findByIdAndDeletedFalse(nonExistingId)).thenReturn(Optional.empty());
 
-        // Act & Assert
         assertThrows(NoSuchElementException.class,
                 () -> listPermissionService.editList(nonExistingId, updateDTO, owner));
+
+        verifyNoInteractions(shoppingListService);
+        verify(listPermissionRepository, never()).save(any());
     }
 
     @Test
-    void findListUserPermissionById_ExistingId_ReturnsPermission() {
-        // Arrange
+    void findListUserPermissionById_Owner_ReturnsPermission() {
         when(listPermissionRepository.findByIdAndDeletedFalse(listPermission.getId()))
                 .thenReturn(Optional.of(listPermission));
 
-        // Act
+        when(shoppingListService.findAndVerifyOwnership(shoppingList.getId(), owner)).thenReturn(shoppingList);
+
         ListPermission result = listPermissionService.findListUserPermissionById(listPermission.getId(), owner);
 
-        // Assert
         assertNotNull(result);
         assertEquals(listPermission, result);
-        verify(listPermissionRepository, times(1)).findByIdAndDeletedFalse(listPermission.getId());
+
+        verify(listPermissionRepository).findByIdAndDeletedFalse(listPermission.getId());
+
+        verify(shoppingListService).findAndVerifyOwnership(shoppingList.getId(), owner);
+    }
+
+    @Test
+    void findListUserPermissionById_NonOwner_ThrowsResourceOwnershipException() {
+        when(listPermissionRepository.findByIdAndDeletedFalse(listPermission.getId()))
+                .thenReturn(Optional.of(listPermission));
+
+        when(shoppingListService.findAndVerifyOwnership(shoppingList.getId(), nonOwner))
+                .thenThrow(new ResourceOwnershipException("Only the list owner can manage permissions"));
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> listPermissionService.findListUserPermissionById(listPermission.getId(), nonOwner));
     }
 
     @Test
     void findListUserPermissionById_NonExistingId_ThrowsNoSuchElementException() {
-        // Arrange
         Long nonExistingId = listPermission.getId() + 1000;
+
         when(listPermissionRepository.findByIdAndDeletedFalse(nonExistingId)).thenReturn(Optional.empty());
 
-        // Act & Assert
         assertThrows(NoSuchElementException.class,
                 () -> listPermissionService.findListUserPermissionById(nonExistingId, owner));
+
+        verifyNoInteractions(shoppingListService);
     }
 
     @Test
-    void removeList_ExistingId_SoftDeletesPermission() {
-        // Arrange
+    void removeList_Owner_SoftDeletesPermission() {
         when(listPermissionRepository.findByIdAndDeletedFalse(listPermission.getId()))
                 .thenReturn(Optional.of(listPermission));
 
-        // Act
+        when(shoppingListService.findAndVerifyOwnership(shoppingList.getId(), owner)).thenReturn(shoppingList);
+
         assertDoesNotThrow(() -> listPermissionService.removeList(listPermission.getId(), owner));
 
-        // Assert
-        verify(auditService, times(1)).softDelete(listPermission);
-        verify(listPermissionRepository, times(1)).save(listPermission);
+        verify(shoppingListService).findAndVerifyOwnership(shoppingList.getId(), owner);
+
+        verify(auditService).softDelete(listPermission);
+        verify(listPermissionRepository).save(listPermission);
+    }
+
+    @Test
+    void removeList_NonOwner_ThrowsResourceOwnershipException() {
+        when(listPermissionRepository.findByIdAndDeletedFalse(listPermission.getId()))
+                .thenReturn(Optional.of(listPermission));
+
+        when(shoppingListService.findAndVerifyOwnership(shoppingList.getId(), nonOwner))
+                .thenThrow(new ResourceOwnershipException("Only the list owner can manage permissions"));
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> listPermissionService.removeList(listPermission.getId(), nonOwner));
+
+        verify(auditService, never()).softDelete(any());
+        verify(listPermissionRepository, never()).save(any());
     }
 
     @Test
     void removeList_NonExistingId_ThrowsNoSuchElementException() {
-        // Arrange
         Long nonExistingId = listPermission.getId() + 1000;
+
         when(listPermissionRepository.findByIdAndDeletedFalse(nonExistingId)).thenReturn(Optional.empty());
 
-        // Act & Assert
         assertThrows(NoSuchElementException.class, () -> listPermissionService.removeList(nonExistingId, owner));
+
+        verifyNoInteractions(shoppingListService);
+        verify(auditService, never()).softDelete(any());
+        verify(listPermissionRepository, never()).save(any());
     }
 
     @Test
-    void findAllPermissionsByListId_ExistingListId_ReturnsPermissions() {
-        // Arrange
-        when(shoppingListService.findAndVerifyAccess(shoppingList.getId(), owner)).thenReturn(shoppingList);
+    void findAllPermissionsByListId_Owner_ReturnsPermissions() {
+        when(shoppingListService.findAndVerifyOwnership(shoppingList.getId(), owner)).thenReturn(shoppingList);
+
         when(listPermissionRepository.findByShoppingListIdAndDeletedFalse(shoppingList.getId()))
                 .thenReturn(List.of(listPermission));
 
-        // Act
         List<ListPermission> result = listPermissionService.findAllPermissionsByListId(shoppingList.getId(), owner);
 
-        // Assert
         assertNotNull(result);
         assertEquals(1, result.size());
         assertEquals(listPermission, result.get(0));
-        verify(listPermissionRepository, times(1)).findByShoppingListIdAndDeletedFalse(shoppingList.getId());
+
+        verify(shoppingListService).findAndVerifyOwnership(shoppingList.getId(), owner);
+
+        verify(listPermissionRepository).findByShoppingListIdAndDeletedFalse(shoppingList.getId());
+    }
+
+    @Test
+    void findAllPermissionsByListId_NonOwner_ThrowsResourceOwnershipException() {
+        when(shoppingListService.findAndVerifyOwnership(shoppingList.getId(), nonOwner))
+                .thenThrow(new ResourceOwnershipException("Only the list owner can manage permissions"));
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> listPermissionService.findAllPermissionsByListId(shoppingList.getId(), nonOwner));
+
+        verify(listPermissionRepository, never()).findByShoppingListIdAndDeletedFalse(anyLong());
     }
 }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/list/service/ShoppingListServiceTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/list/service/ShoppingListServiceTest.java
@@ -1,12 +1,17 @@
 package com.omatheusmesmo.shoppmate.list.service;
 
+import com.omatheusmesmo.shoppmate.list.entity.ListPermission;
+import com.omatheusmesmo.shoppmate.list.entity.Permission;
 import com.omatheusmesmo.shoppmate.list.entity.ShoppingList;
+import com.omatheusmesmo.shoppmate.list.mapper.ListMapper;
+import com.omatheusmesmo.shoppmate.list.repository.ListPermissionRepository;
 import com.omatheusmesmo.shoppmate.list.repository.ShoppingListRepository;
 import com.omatheusmesmo.shoppmate.shared.service.AuditService;
 import com.omatheusmesmo.shoppmate.shared.testutils.ListTestFactory;
 import com.omatheusmesmo.shoppmate.shared.testutils.UserTestFactory;
 import com.omatheusmesmo.shoppmate.user.entity.User;
 import com.omatheusmesmo.shoppmate.user.service.UserService;
+import com.omatheusmesmo.shoppmate.utils.exception.ResourceOwnershipException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,108 +32,264 @@ class ShoppingListServiceTest {
     private ShoppingListRepository shoppingListRepository;
 
     @Mock
+    private ListPermissionRepository listPermissionRepository;
+
+    @Mock
     private AuditService auditService;
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private ListMapper listMapper;
 
     @InjectMocks
     private ShoppingListService shoppingListService;
 
     private ShoppingList testList;
     private User testUser;
+    private User sharedUser;
+    private User unrelatedUser;
+    private ListPermission readPermission;
+    private ListPermission writePermission;
 
     @BeforeEach
     void setUp() {
         testList = ListTestFactory.createValidShoppingList();
         testUser = testList.getOwner();
+
+        sharedUser = UserTestFactory.createValidUser();
+        unrelatedUser = UserTestFactory.createValidUser();
+
+        readPermission = new ListPermission();
+        readPermission.setShoppingList(testList);
+        readPermission.setUser(sharedUser);
+        readPermission.setPermission(Permission.READ);
+
+        writePermission = new ListPermission();
+        writePermission.setShoppingList(testList);
+        writePermission.setUser(sharedUser);
+        writePermission.setPermission(Permission.WRITE);
     }
 
     @Test
     void saveList_ValidList_ReturnsSavedList() {
-        // Act
         ShoppingList result = shoppingListService.saveList(testList);
 
-        // Assert
         assertNotNull(result);
         assertEquals(testList.getName(), result.getName());
-        verify(auditService, times(1)).setAuditData(testList, true);
-        verify(shoppingListRepository, times(1)).save(testList);
+
+        verify(auditService).setAuditData(testList, true);
+        verify(shoppingListRepository).save(testList);
     }
 
     @Test
     void findListById_ExistingId_ReturnsList() {
-        // Arrange
         when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
 
-        // Act
         ShoppingList result = shoppingListService.findListById(testList.getId());
 
-        // Assert
         assertNotNull(result);
         assertEquals(testList.getId(), result.getId());
         assertEquals(testList.getName(), result.getName());
-        verify(shoppingListRepository, times(1)).findByIdAndDeletedFalse(testList.getId());
+
+        verify(shoppingListRepository).findByIdAndDeletedFalse(testList.getId());
     }
 
     @Test
     void findListById_NonExistingId_ThrowsNoSuchElementException() {
-        // Arrange
         Long nonExistingId = testList.getId() + 1000;
+
         when(shoppingListRepository.findByIdAndDeletedFalse(nonExistingId)).thenReturn(Optional.empty());
 
-        // Act & Assert
         assertThrows(NoSuchElementException.class, () -> shoppingListService.findListById(nonExistingId));
-        verify(shoppingListRepository, times(1)).findByIdAndDeletedFalse(nonExistingId);
+
+        verify(shoppingListRepository).findByIdAndDeletedFalse(nonExistingId);
     }
 
     @Test
     void removeList_ExistingId_DeletesList() {
-        // Arrange
         when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
 
-        // Act & Assert
         assertDoesNotThrow(() -> shoppingListService.removeList(testList.getId(), testUser));
 
-        // Assert
-        verify(shoppingListRepository, times(1)).deleteById(testList.getId());
+        verify(shoppingListRepository).deleteById(testList.getId());
     }
 
     @Test
     void removeList_NonExistingId_ThrowsNoSuchElementException() {
-        // Arrange
         Long nonExistingId = testList.getId() + 1000;
+
         when(shoppingListRepository.findByIdAndDeletedFalse(nonExistingId)).thenReturn(Optional.empty());
 
-        // Act & Assert
         assertThrows(NoSuchElementException.class, () -> shoppingListService.removeList(nonExistingId, testUser));
+
         verify(shoppingListRepository, never()).deleteById(anyLong());
     }
 
     @Test
     void saveList_NameIsNull_ThrowsIllegalArgumentException() {
-        // Arrange
         testList.setName(null);
 
-        // Act & Assert
         assertThrows(IllegalArgumentException.class, () -> shoppingListService.saveList(testList));
+
         verify(shoppingListRepository, never()).save(any());
     }
 
     @Test
     void editList_ExistingList_ReturnsUpdatedList() {
-        // Arrange
         String updatedName = testList.getName() + " Updated";
         testList.setName(updatedName);
+
         when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
 
-        // Act
         ShoppingList result = shoppingListService.editList(testList, testUser);
 
-        // Assert
         assertNotNull(result);
         assertEquals(updatedName, result.getName());
-        verify(auditService, times(1)).setAuditData(testList, false);
-        verify(shoppingListRepository, times(1)).save(testList);
+
+        verify(auditService).setAuditData(testList, false);
+        verify(shoppingListRepository).save(testList);
+    }
+
+    @Test
+    void findAndVerifyReadAccess_Owner_ReturnsList() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        ShoppingList result = shoppingListService.findAndVerifyReadAccess(testList.getId(), testUser);
+
+        assertSame(testList, result);
+
+        verify(listPermissionRepository, never()).findByShoppingListIdAndUserIdAndDeletedFalse(anyLong(), anyLong());
+    }
+
+    @Test
+    void findAndVerifyReadAccess_ReadPermission_ReturnsList() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        when(listPermissionRepository.findByShoppingListIdAndUserIdAndDeletedFalse(testList.getId(),
+                sharedUser.getId())).thenReturn(Optional.of(readPermission));
+
+        ShoppingList result = shoppingListService.findAndVerifyReadAccess(testList.getId(), sharedUser);
+
+        assertSame(testList, result);
+    }
+
+    @Test
+    void findAndVerifyReadAccess_WritePermission_ReturnsList() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        when(listPermissionRepository.findByShoppingListIdAndUserIdAndDeletedFalse(testList.getId(),
+                sharedUser.getId())).thenReturn(Optional.of(writePermission));
+
+        ShoppingList result = shoppingListService.findAndVerifyReadAccess(testList.getId(), sharedUser);
+
+        assertSame(testList, result);
+    }
+
+    @Test
+    void findAndVerifyReadAccess_UnrelatedUser_ThrowsResourceOwnershipException() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        when(listPermissionRepository.findByShoppingListIdAndUserIdAndDeletedFalse(testList.getId(),
+                unrelatedUser.getId())).thenReturn(Optional.empty());
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> shoppingListService.findAndVerifyReadAccess(testList.getId(), unrelatedUser));
+    }
+
+    @Test
+    void findAndVerifyReadAccess_DeletedPermission_ThrowsResourceOwnershipException() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        when(listPermissionRepository.findByShoppingListIdAndUserIdAndDeletedFalse(testList.getId(),
+                sharedUser.getId())).thenReturn(Optional.empty());
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> shoppingListService.findAndVerifyReadAccess(testList.getId(), sharedUser));
+    }
+
+    @Test
+    void findAndVerifyWriteAccess_Owner_ReturnsList() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        ShoppingList result = shoppingListService.findAndVerifyWriteAccess(testList.getId(), testUser);
+
+        assertSame(testList, result);
+
+        verify(listPermissionRepository, never()).findByShoppingListIdAndUserIdAndDeletedFalse(anyLong(), anyLong());
+    }
+
+    @Test
+    void findAndVerifyWriteAccess_WritePermission_ReturnsList() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        when(listPermissionRepository.findByShoppingListIdAndUserIdAndDeletedFalse(testList.getId(),
+                sharedUser.getId())).thenReturn(Optional.of(writePermission));
+
+        ShoppingList result = shoppingListService.findAndVerifyWriteAccess(testList.getId(), sharedUser);
+
+        assertSame(testList, result);
+    }
+
+    @Test
+    void findAndVerifyWriteAccess_ReadPermission_ThrowsResourceOwnershipException() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        when(listPermissionRepository.findByShoppingListIdAndUserIdAndDeletedFalse(testList.getId(),
+                sharedUser.getId())).thenReturn(Optional.of(readPermission));
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> shoppingListService.findAndVerifyWriteAccess(testList.getId(), sharedUser));
+    }
+
+    @Test
+    void findAndVerifyWriteAccess_UnrelatedUser_ThrowsResourceOwnershipException() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        when(listPermissionRepository.findByShoppingListIdAndUserIdAndDeletedFalse(testList.getId(),
+                unrelatedUser.getId())).thenReturn(Optional.empty());
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> shoppingListService.findAndVerifyWriteAccess(testList.getId(), unrelatedUser));
+    }
+
+    @Test
+    void findAndVerifyOwnership_Owner_ReturnsList() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        ShoppingList result = shoppingListService.findAndVerifyOwnership(testList.getId(), testUser);
+
+        assertSame(testList, result);
+    }
+
+    @Test
+    void findAndVerifyOwnership_ReadUser_ThrowsResourceOwnershipException() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> shoppingListService.findAndVerifyOwnership(testList.getId(), sharedUser));
+
+        verifyNoInteractions(listPermissionRepository);
+    }
+
+    @Test
+    void findAndVerifyOwnership_WriteUser_ThrowsResourceOwnershipException() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> shoppingListService.findAndVerifyOwnership(testList.getId(), sharedUser));
+
+        verifyNoInteractions(listPermissionRepository);
+    }
+
+    @Test
+    void findAndVerifyOwnership_UnrelatedUser_ThrowsResourceOwnershipException() {
+        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
+
+        assertThrows(ResourceOwnershipException.class,
+                () -> shoppingListService.findAndVerifyOwnership(testList.getId(), unrelatedUser));
+
+        verifyNoInteractions(listPermissionRepository);
     }
 }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/list/service/ShoppingListServiceTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/list/service/ShoppingListServiceTest.java
@@ -264,31 +264,11 @@ class ShoppingListServiceTest {
     }
 
     @Test
-    void findAndVerifyOwnership_ReadUser_ThrowsResourceOwnershipException() {
+    void findAndVerifyOwnership_NonOwnerUser_ThrowsResourceOwnershipException() {
         when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
 
         assertThrows(ResourceOwnershipException.class,
                 () -> shoppingListService.findAndVerifyOwnership(testList.getId(), sharedUser));
-
-        verifyNoInteractions(listPermissionRepository);
-    }
-
-    @Test
-    void findAndVerifyOwnership_WriteUser_ThrowsResourceOwnershipException() {
-        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
-
-        assertThrows(ResourceOwnershipException.class,
-                () -> shoppingListService.findAndVerifyOwnership(testList.getId(), sharedUser));
-
-        verifyNoInteractions(listPermissionRepository);
-    }
-
-    @Test
-    void findAndVerifyOwnership_UnrelatedUser_ThrowsResourceOwnershipException() {
-        when(shoppingListRepository.findByIdAndDeletedFalse(testList.getId())).thenReturn(Optional.of(testList));
-
-        assertThrows(ResourceOwnershipException.class,
-                () -> shoppingListService.findAndVerifyOwnership(testList.getId(), unrelatedUser));
 
         verifyNoInteractions(listPermissionRepository);
     }

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/shared/testutils/ListTestFactory.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/shared/testutils/ListTestFactory.java
@@ -9,6 +9,9 @@ import com.omatheusmesmo.shoppmate.list.entity.ListItem;
 import com.omatheusmesmo.shoppmate.list.entity.ListPermission;
 import com.omatheusmesmo.shoppmate.list.entity.Permission;
 import com.omatheusmesmo.shoppmate.list.entity.ShoppingList;
+import com.omatheusmesmo.shoppmate.list.repository.ListPermissionRepository;
+import com.omatheusmesmo.shoppmate.user.entity.User;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicLong;
@@ -52,6 +55,18 @@ public class ListTestFactory {
         permission.setUpdatedAt(LocalDateTime.now());
         permission.setDeleted(false);
         return permission;
+    }
+
+    public static ListPermission grantPermission(ShoppingList shoppingList, User user, Permission permission,
+            ListPermissionRepository listPermissionRepository) {
+
+        ListPermission listPermission = createValidListPermission(shoppingList);
+        listPermission.setId(null);
+        listPermission.setShoppingList(shoppingList);
+        listPermission.setUser(user);
+        listPermission.setPermission(permission);
+
+        return listPermissionRepository.save(listPermission);
     }
 
     public static ShoppingListRequestDTO createValidShoppingListRequestDTO() {

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/unit/repository/UnitRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/unit/repository/UnitRepositoryIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.omatheusmesmo.shoppmate.unit.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.omatheusmesmo.shoppmate.shared.testcontainers.AbstractIntegrationTest;
+import com.omatheusmesmo.shoppmate.unit.entity.Unit;
+import com.omatheusmesmo.shoppmate.user.entity.User;
+import com.omatheusmesmo.shoppmate.user.repository.UserRepository;
+
+class UnitRepositoryIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private UnitRepository unitRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User currentUser;
+    private User otherUser;
+
+    @BeforeEach
+    void setUp() {
+        unitRepository.deleteAll();
+        userRepository.deleteAll();
+
+        currentUser = createUser("current-unit-user@example.com");
+        otherUser = createUser("other-unit-user@example.com");
+    }
+
+    @Test
+    void findAccessibleByIdAndUserId_OwnUnit_ReturnsUnit() {
+        Unit unit = createUnit("Own Unit", "own", currentUser, false, false);
+
+        Optional<Unit> result = unitRepository.findAccessibleByIdAndUserId(unit.getId(), currentUser.getId());
+
+        assertTrue(result.isPresent());
+        assertEquals(unit.getId(), result.get().getId());
+    }
+
+    @Test
+    void findAccessibleByIdAndUserId_SystemUnit_ReturnsUnit() {
+        Unit unit = createUnit("System Unit", "sys", null, true, false);
+
+        Optional<Unit> result = unitRepository.findAccessibleByIdAndUserId(unit.getId(), currentUser.getId());
+
+        assertTrue(result.isPresent());
+        assertEquals(unit.getId(), result.get().getId());
+    }
+
+    @Test
+    void findAccessibleByIdAndUserId_OtherUsersUnit_ReturnsEmpty() {
+        Unit unit = createUnit("Other User Unit", "other", otherUser, false, false);
+
+        Optional<Unit> result = unitRepository.findAccessibleByIdAndUserId(unit.getId(), currentUser.getId());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findAccessibleByIdAndUserId_DeletedOwnedUnit_ReturnsEmpty() {
+        Unit unit = createUnit("Deleted Unit", "deleted", currentUser, false, true);
+
+        Optional<Unit> result = unitRepository.findAccessibleByIdAndUserId(unit.getId(), currentUser.getId());
+
+        assertTrue(result.isEmpty());
+    }
+
+    private User createUser(String email) {
+        User user = new User();
+        user.setEmail(email);
+        user.setFullName("Repository Test User");
+        user.setPassword("password");
+        user.setRole("USER");
+        user.setDeleted(false);
+
+        return userRepository.save(user);
+    }
+
+    private Unit createUnit(String name, String symbol, User owner, boolean systemStandard, boolean deleted) {
+
+        Unit unit = new Unit();
+        unit.setName(name);
+        unit.setSymbol(symbol);
+        unit.setOwner(owner);
+        unit.setSystemStandard(systemStandard);
+        unit.setDeleted(deleted);
+
+        return unitRepository.save(unit);
+    }
+}

--- a/backend/src/test/java/com/omatheusmesmo/shoppmate/unit/service/UnitServiceTest.java
+++ b/backend/src/test/java/com/omatheusmesmo/shoppmate/unit/service/UnitServiceTest.java
@@ -88,6 +88,31 @@ class UnitServiceTest {
     }
 
     @Test
+    void findAccessibleUnitById_AccessibleUnit_ReturnsUnit() {
+        // Arrange
+        when(unitRepository.findAccessibleByIdAndUserId(unit.getId(), user.getId())).thenReturn(Optional.of(unit));
+
+        // Act
+        Unit result = unitService.findAccessibleUnitById(unit.getId(), user);
+
+        // Assert
+        assertEquals(unit, result);
+
+        verify(unitRepository).findAccessibleByIdAndUserId(unit.getId(), user.getId());
+    }
+
+    @Test
+    void findAccessibleUnitById_InaccessibleUnit_ThrowsNoSuchElementException() {
+        // Arrange
+        when(unitRepository.findAccessibleByIdAndUserId(unit.getId(), user.getId())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(NoSuchElementException.class, () -> unitService.findAccessibleUnitById(unit.getId(), user));
+
+        verify(unitRepository).findAccessibleByIdAndUserId(unit.getId(), user.getId());
+    }
+
+    @Test
     void isUnitValid_BlankSymbol_ThrowsIllegalArgumentException() {
         // Arrange
         unit.setSymbol(" ");


### PR DESCRIPTION
## Summary

Implements service-level Broken Object Level Authorization protections for shopping lists, list items, categories, and units.

## Changes

- Centralized shopping-list READ, WRITE, and ownership checks
- Enforced parent-list authorization for list-item operations
- Restricted permission administration to list owners
- Restricted category access to system-standard or user-owned categories
- Restricted unit access to system-standard or user-owned units
- Updated item create/update flows to validate category and unit access
- Removed repository lookups from ItemMapper
- Added service, controller, and repository integration tests

## Verification

- Tests run: 236
- Failures: 0
- Errors: 0
- Skipped: 0

## Note

Standalone Item ownership is not enforced because the current Item entity has no owner relationship. This requires a separate domain decision on whether items are global or user-owned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission-based read/write/ownership access controls for shopping lists and list items.
  * Updated item creation and editing to use the authenticated user and only allow selecting accessible categories/units.
* **Bug Fixes**
  * Fixed category and unit access filtering, including correct “not found” handling and stricter ownership checks for edits.
  * Improved list-item and shopping-list access resolution to consistently enforce read vs. write access.
* **Tests**
  * Expanded unit/category integration tests and broadened security coverage for shared-list permission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->